### PR TITLE
Allow seeking on devices that check headers for supported features

### DIFF
--- a/src/web/handlers.rs
+++ b/src/web/handlers.rs
@@ -489,7 +489,9 @@ pub async fn serve_media(
 
     let mut response_builder = Response::builder()
         .header(header::CONTENT_TYPE, file_info.mime_type)
-        .header(header::ACCEPT_RANGES, "bytes");
+        .header(header::ACCEPT_RANGES, "bytes")
+        .header("transferMode.dlna.org", "Streaming")
+        .header("contentFeatures.dlna.org", "DLNA.ORG_OP=11;DLNA.ORG_CI=0;DLNA.ORG_FLAGS=01700000000000000000000000000000");
 
     let (start, end) = if let Some(range_header) = headers.get(header::RANGE) {
         let range_str = range_header.to_str().map_err(|_| AppError::InvalidRange)?;

--- a/src/web/xml.rs
+++ b/src/web/xml.rs
@@ -261,9 +261,9 @@ pub async fn generate_browse_response_with_totals(
 
             // Use enhanced DLNA flags that support autoplay and streaming
             let dlna_flags = if state.config.media.autoplay_enabled {
-                "DLNA.ORG_PN=;DLNA.ORG_OP=01;DLNA.ORG_FLAGS=01700000000000000000000000000000"
+                "DLNA.ORG_PN=;DLNA.ORG_OP=11;DLNA.ORG_FLAGS=01700000000000000000000000000000"
             } else {
-                "DLNA.ORG_PN=;DLNA.ORG_OP=01;DLNA.ORG_FLAGS=00D00000000000000000000000000000"
+                "DLNA.ORG_PN=;DLNA.ORG_OP=11;DLNA.ORG_FLAGS=00D00000000000000000000000000000"
             };
 
             let item_xml = format!(


### PR DESCRIPTION
This makes streaming work on my Samsung TV with Tizen OS which otherwise will not allow seeking (and not even pausing/resuming).