### PR TITLE
feat(remux): add MKV web player playback with multi-audio track selection

### DIFF
--- a/crates/vuio-core/Cargo.toml
+++ b/crates/vuio-core/Cargo.toml
@@ -99,7 +99,7 @@ hap-tlv8 = { version = "1.0", optional = true }
 hkdf = { version = "0.12", optional = true }
 sha2 = { version = "0.10", optional = true }
 num-bigint = { version = "0.4", optional = true }
-symphonia = { version = "0.6", default-features = false, features = ["mp3", "aac", "isomp4", "flac", "wav", "pcm", "ogg", "vorbis", "alac", "id3v1", "id3v2", "ape"], optional = true }
+symphonia = { version = "0.6", default-features = false, features = ["mkv", "mp3", "aac", "isomp4", "flac", "wav", "pcm", "ogg", "vorbis", "alac", "id3v1", "id3v2", "ape"], optional = true }
 getrandom = { version = "0.3", optional = true }
 plist = { version = "1.8", optional = true }
 hex = { version = "0.4", optional = true }

--- a/crates/vuio-core/src/media.rs
+++ b/crates/vuio-core/src/media.rs
@@ -16,6 +16,7 @@ const BATCH_SIZE: usize = 1000;
 /// startup scans, reconciliation and watcher filtering so those paths cannot
 /// disagree about what belongs in the catalog.
 mod policy;
+pub mod remux;
 mod result;
 mod scanner;
 

--- a/crates/vuio-core/src/media/remux/fmp4_writer.rs
+++ b/crates/vuio-core/src/media/remux/fmp4_writer.rs
@@ -1,0 +1,563 @@
+//! Pure Rust ISO BMFF / fMP4 (CMAF) box serializer.
+
+use super::mkv_demuxer::{MediaPacket, TrackInfo, TrackKind};
+
+pub struct SampleInfo {
+    pub duration: u32,
+    pub size: u32,
+    pub is_keyframe: bool,
+}
+
+pub struct Fmp4Writer;
+
+impl Fmp4Writer {
+    /// Build `ftyp` (File Type) box for fMP4 CMAF compatibility.
+    pub fn build_ftyp() -> Vec<u8> {
+        let mut box_data = Vec::with_capacity(32);
+        box_data.extend_from_slice(b"ftyp");
+        box_data.extend_from_slice(b"iso8"); // major_brand
+        box_data.extend_from_slice(&[0, 0, 0, 1]); // minor_version = 1
+        box_data.extend_from_slice(b"iso8mp41dashmp42"); // compatible_brands
+
+        Self::wrap_box(&box_data)
+    }
+
+    /// Build `moov` (Movie Header) init segment box for a track.
+    pub fn build_moov(track: &TrackInfo) -> Vec<u8> {
+        let mut moov_body = Vec::new();
+
+        // 1. mvhd (Movie Header)
+        let mut mvhd = Vec::new();
+        mvhd.extend_from_slice(b"mvhd");
+        mvhd.push(0); // version 0
+        mvhd.extend_from_slice(&[0; 3]); // flags
+        mvhd.extend_from_slice(&[0; 4]); // creation_time
+        mvhd.extend_from_slice(&[0; 4]); // modification_time
+        mvhd.extend_from_slice(&(1000u32).to_be_bytes()); // timescale = 1000 Hz
+        mvhd.extend_from_slice(&(0u32).to_be_bytes()); // duration = 0 for fMP4 init
+        mvhd.extend_from_slice(&(0x00010000u32).to_be_bytes()); // rate = 1.0
+        mvhd.extend_from_slice(&(0x0100u16).to_be_bytes()); // volume = 1.0
+        mvhd.extend_from_slice(&[0; 10]); // reserved
+                                          // Matrix structure (identity matrix)
+        mvhd.extend_from_slice(&(0x00010000u32).to_be_bytes());
+        mvhd.extend_from_slice(&[0; 12]);
+        mvhd.extend_from_slice(&(0x00010000u32).to_be_bytes());
+        mvhd.extend_from_slice(&[0; 12]);
+        mvhd.extend_from_slice(&(0x40000000u32).to_be_bytes());
+        mvhd.extend_from_slice(&[0; 24]); // pre_defined
+        mvhd.extend_from_slice(&(2u32).to_be_bytes()); // next_track_id
+        moov_body.extend_from_slice(&Self::wrap_box(&mvhd));
+
+        // 2. trak (Track Atom)
+        let trak = Self::build_trak(track);
+        moov_body.extend_from_slice(&trak);
+
+        // 3. mvex (Movie Extends Atom)
+        let mvex = Self::build_mvex(track.id);
+        moov_body.extend_from_slice(&mvex);
+
+        let mut moov = Vec::new();
+        moov.extend_from_slice(b"moov");
+        moov.extend_from_slice(&moov_body);
+        Self::wrap_box(&moov)
+    }
+
+    /// Return the timescale appropriate for a given track kind.
+    ///
+    /// - Video: 90 000 Hz (industry standard for MPEG-TS / HLS / DASH)
+    /// - Audio: the track's sample rate (e.g. 48 000, 44 100)
+    pub fn timescale_for(track: &TrackInfo) -> u32 {
+        match track.track_kind {
+            TrackKind::Video => 90_000,
+            TrackKind::Audio => track.sample_rate.unwrap_or(44_100),
+            TrackKind::Other => 1_000,
+        }
+    }
+
+    fn build_trak(track: &TrackInfo) -> Vec<u8> {
+        let mut trak_body = Vec::new();
+
+        // tkhd (Track Header)
+        let mut tkhd = Vec::new();
+        tkhd.extend_from_slice(b"tkhd");
+        tkhd.push(0); // version
+        tkhd.extend_from_slice(&[0, 0, 7]); // flags = enabled + in_movie + in_preview
+        tkhd.extend_from_slice(&[0; 4]); // creation_time
+        tkhd.extend_from_slice(&[0; 4]); // modification_time
+        tkhd.extend_from_slice(&track.id.to_be_bytes()); // track_id
+        tkhd.extend_from_slice(&[0; 4]); // reserved
+        tkhd.extend_from_slice(&[0; 4]); // duration
+        tkhd.extend_from_slice(&[0; 8]); // reserved
+        tkhd.extend_from_slice(&[0; 2]); // layer
+        tkhd.extend_from_slice(&[0; 2]); // alternate_group
+        let vol = if track.track_kind == TrackKind::Audio {
+            0x0100u16
+        } else {
+            0
+        };
+        tkhd.extend_from_slice(&vol.to_be_bytes()); // volume
+        tkhd.extend_from_slice(&[0; 2]); // reserved
+                                          // Matrix structure
+        tkhd.extend_from_slice(&(0x00010000u32).to_be_bytes());
+        tkhd.extend_from_slice(&[0; 12]);
+        tkhd.extend_from_slice(&(0x00010000u32).to_be_bytes());
+        tkhd.extend_from_slice(&[0; 12]);
+        tkhd.extend_from_slice(&(0x40000000u32).to_be_bytes());
+
+        let w = (track.width.unwrap_or(0) << 16).to_be_bytes();
+        let h = (track.height.unwrap_or(0) << 16).to_be_bytes();
+        tkhd.extend_from_slice(&w); // width
+        tkhd.extend_from_slice(&h); // height
+        trak_body.extend_from_slice(&Self::wrap_box(&tkhd));
+
+        // mdia (Media Atom)
+        let mdia = Self::build_mdia(track);
+        trak_body.extend_from_slice(&mdia);
+
+        let mut trak = Vec::new();
+        trak.extend_from_slice(b"trak");
+        trak.extend_from_slice(&trak_body);
+        Self::wrap_box(&trak)
+    }
+
+    fn build_mdia(track: &TrackInfo) -> Vec<u8> {
+        let mut mdia_body = Vec::new();
+
+        // mdhd (Media Header)
+        let timescale = Self::timescale_for(track);
+        let mut mdhd = Vec::new();
+        mdhd.extend_from_slice(b"mdhd");
+        mdhd.push(0); // version
+        mdhd.extend_from_slice(&[0; 3]); // flags
+        mdhd.extend_from_slice(&[0; 4]); // creation_time
+        mdhd.extend_from_slice(&[0; 4]); // modification_time
+        mdhd.extend_from_slice(&timescale.to_be_bytes());
+        mdhd.extend_from_slice(&[0; 4]); // duration
+        mdhd.extend_from_slice(&[0x55, 0xc4]); // lang: "und"
+        mdhd.extend_from_slice(&[0; 2]); // pre_defined
+        mdia_body.extend_from_slice(&Self::wrap_box(&mdhd));
+
+        // hdlr (Handler Reference Atom)
+        let (handler_type, name) = match track.track_kind {
+            TrackKind::Video => (b"vide", "VideoHandler"),
+            TrackKind::Audio => (b"soun", "SoundHandler"),
+            TrackKind::Other => (b"hint", "HintHandler"),
+        };
+        let mut hdlr = Vec::new();
+        hdlr.extend_from_slice(b"hdlr");
+        hdlr.extend_from_slice(&[0; 4]); // version + flags
+        hdlr.extend_from_slice(&[0; 4]); // pre_defined
+        hdlr.extend_from_slice(handler_type);
+        hdlr.extend_from_slice(&[0; 12]); // reserved
+        hdlr.extend_from_slice(name.as_bytes());
+        hdlr.push(0); // null term
+        mdia_body.extend_from_slice(&Self::wrap_box(&hdlr));
+
+        // minf (Media Information Atom)
+        let minf = Self::build_minf(track);
+        mdia_body.extend_from_slice(&minf);
+
+        let mut mdia = Vec::new();
+        mdia.extend_from_slice(b"mdia");
+        mdia.extend_from_slice(&mdia_body);
+        Self::wrap_box(&mdia)
+    }
+
+    fn build_minf(track: &TrackInfo) -> Vec<u8> {
+        let mut minf_body = Vec::new();
+
+        if track.track_kind == TrackKind::Video {
+            let mut vmhd = Vec::new();
+            vmhd.extend_from_slice(b"vmhd");
+            vmhd.extend_from_slice(&[0, 0, 0, 1]); // version + flags
+            vmhd.extend_from_slice(&[0; 8]); // graphicsmode + opcolor
+            minf_body.extend_from_slice(&Self::wrap_box(&vmhd));
+        } else {
+            let mut smhd = Vec::new();
+            smhd.extend_from_slice(b"smhd");
+            smhd.extend_from_slice(&[0; 4]); // version + flags
+            smhd.extend_from_slice(&[0; 4]); // balance + reserved
+            minf_body.extend_from_slice(&Self::wrap_box(&smhd));
+        }
+
+        // dinf -> dref -> url
+        let mut url = Vec::new();
+        url.extend_from_slice(b"url ");
+        url.extend_from_slice(&[0, 0, 0, 1]); // version + flags (self-contained)
+        let url_box = Self::wrap_box(&url);
+
+        let mut dref = Vec::new();
+        dref.extend_from_slice(b"dref");
+        dref.extend_from_slice(&[0; 4]); // version + flags
+        dref.extend_from_slice(&(1u32).to_be_bytes()); // entry count
+        dref.extend_from_slice(&url_box);
+        let dref_box = Self::wrap_box(&dref);
+
+        let mut dinf = Vec::new();
+        dinf.extend_from_slice(b"dinf");
+        dinf.extend_from_slice(&dref_box);
+        minf_body.extend_from_slice(&Self::wrap_box(&dinf));
+
+        // stbl (Sample Table)
+        let stbl = Self::build_stbl(track);
+        minf_body.extend_from_slice(&stbl);
+
+        let mut minf = Vec::new();
+        minf.extend_from_slice(b"minf");
+        minf.extend_from_slice(&minf_body);
+        Self::wrap_box(&minf)
+    }
+
+    fn build_stbl(track: &TrackInfo) -> Vec<u8> {
+        let mut stbl_body = Vec::new();
+
+        // stsd (Sample Description Atom)
+        let mut stsd = Vec::new();
+        stsd.extend_from_slice(b"stsd");
+        stsd.extend_from_slice(&[0; 4]); // version + flags
+        stsd.extend_from_slice(&(1u32).to_be_bytes()); // entry count
+
+        let entry_box = if track.track_kind == TrackKind::Video {
+            let mut sample_entry = Vec::new();
+            sample_entry.extend_from_slice(b"avc1");
+            sample_entry.extend_from_slice(&[0; 6]); // reserved
+            sample_entry.extend_from_slice(&(1u16).to_be_bytes()); // data_reference_index
+            sample_entry.extend_from_slice(&[0; 16]); // pre_defined + reserved
+            sample_entry.extend_from_slice(&(track.width.unwrap_or(1920) as u16).to_be_bytes());
+            sample_entry.extend_from_slice(&(track.height.unwrap_or(1080) as u16).to_be_bytes());
+            sample_entry.extend_from_slice(&(0x00480000u32).to_be_bytes()); // horiz resolution 72 dpi
+            sample_entry.extend_from_slice(&(0x00480000u32).to_be_bytes()); // vert resolution 72 dpi
+            sample_entry.extend_from_slice(&[0; 4]); // reserved
+            sample_entry.extend_from_slice(&(1u16).to_be_bytes()); // frame_count = 1
+            sample_entry.extend_from_slice(&[0; 32]); // compressorname
+            sample_entry.extend_from_slice(&(0x0018u16).to_be_bytes()); // depth = 24
+            sample_entry.extend_from_slice(&(-1i16).to_be_bytes()); // pre_defined = -1
+
+            if !track.extra_data.is_empty() {
+                let mut avcc = Vec::new();
+                avcc.extend_from_slice(b"avcC");
+                avcc.extend_from_slice(&track.extra_data);
+                sample_entry.extend_from_slice(&Self::wrap_box(&avcc));
+            }
+            Self::wrap_box(&sample_entry)
+        } else {
+            let mut sample_entry = Vec::new();
+            sample_entry.extend_from_slice(b"mp4a");
+            sample_entry.extend_from_slice(&[0; 6]); // reserved
+            sample_entry.extend_from_slice(&(1u16).to_be_bytes()); // data_reference_index
+            sample_entry.extend_from_slice(&[0; 8]); // reserved
+            sample_entry
+                .extend_from_slice(&(track.channels.unwrap_or(2) as u16).to_be_bytes());
+            sample_entry.extend_from_slice(&(16u16).to_be_bytes()); // sample_size = 16
+            sample_entry.extend_from_slice(&[0; 4]); // pre_defined + reserved
+            sample_entry.extend_from_slice(
+                &(track.sample_rate.unwrap_or(44100) << 16).to_be_bytes(),
+            );
+
+            if !track.extra_data.is_empty() {
+                let mut esds = Vec::new();
+                esds.extend_from_slice(b"esds");
+                esds.extend_from_slice(&[0; 4]); // version + flags
+                esds.extend_from_slice(&track.extra_data);
+                sample_entry.extend_from_slice(&Self::wrap_box(&esds));
+            }
+            Self::wrap_box(&sample_entry)
+        };
+        stsd.extend_from_slice(&entry_box);
+        stbl_body.extend_from_slice(&Self::wrap_box(&stsd));
+
+        // Empty stts, stsc, stsz, stco for fMP4
+        for tag in &[b"stts", b"stsc", b"stsz", b"stco"] {
+            let mut empty_box = Vec::new();
+            empty_box.extend_from_slice(*tag);
+            empty_box.extend_from_slice(&[0; 4]); // version + flags
+            empty_box.extend_from_slice(&[0; 4]); // entry count = 0
+            stbl_body.extend_from_slice(&Self::wrap_box(&empty_box));
+        }
+
+        let mut stbl = Vec::new();
+        stbl.extend_from_slice(b"stbl");
+        stbl.extend_from_slice(&stbl_body);
+        Self::wrap_box(&stbl)
+    }
+
+    fn build_mvex(track_id: u32) -> Vec<u8> {
+        let mut trex = Vec::new();
+        trex.extend_from_slice(b"trex");
+        trex.extend_from_slice(&[0; 4]); // version + flags
+        trex.extend_from_slice(&track_id.to_be_bytes());
+        trex.extend_from_slice(&(1u32).to_be_bytes()); // default_sample_description_index
+        trex.extend_from_slice(&[0; 12]); // default duration, size, flags
+
+        let mut mvex = Vec::new();
+        mvex.extend_from_slice(b"mvex");
+        mvex.extend_from_slice(&Self::wrap_box(&trex));
+        Self::wrap_box(&mvex)
+    }
+
+    /// Build `moof` (Movie Fragment) box for a sequence of samples.
+    pub fn build_moof(
+        sequence_number: u32,
+        track_id: u32,
+        base_decode_time: u64,
+        samples: &[SampleInfo],
+        data_offset: u32,
+    ) -> Vec<u8> {
+        let mut moof_body = Vec::new();
+
+        // mfhd (Movie Fragment Header)
+        let mut mfhd = Vec::new();
+        mfhd.extend_from_slice(b"mfhd");
+        mfhd.extend_from_slice(&[0; 4]); // version + flags
+        mfhd.extend_from_slice(&sequence_number.to_be_bytes());
+        moof_body.extend_from_slice(&Self::wrap_box(&mfhd));
+
+        // traf (Track Fragment)
+        let mut traf_body = Vec::new();
+
+        // tfhd (Track Fragment Header)
+        let mut tfhd = Vec::new();
+        tfhd.extend_from_slice(b"tfhd");
+        tfhd.extend_from_slice(&[0, 0, 0, 0x20]); // flags = default-base-is-moof
+        tfhd.extend_from_slice(&track_id.to_be_bytes());
+        traf_body.extend_from_slice(&Self::wrap_box(&tfhd));
+
+        // tfdt (Track Fragment Decode Time)
+        let mut tfdt = Vec::new();
+        tfdt.extend_from_slice(b"tfdt");
+        tfdt.push(1); // version 1 (64-bit)
+        tfdt.extend_from_slice(&[0; 3]); // flags
+        tfdt.extend_from_slice(&base_decode_time.to_be_bytes());
+        traf_body.extend_from_slice(&Self::wrap_box(&tfdt));
+
+        // trun (Track Run)
+        let mut trun = Vec::new();
+        trun.extend_from_slice(b"trun");
+        // flags: data-offset-present (0x001) | sample-duration-present (0x100)
+        //      | sample-size-present (0x200) | sample-flags-present (0x400)
+        // = 0x000701 in 24-bit flags field
+        trun.extend_from_slice(&[0, 0, 0x07, 0x01]);
+        trun.extend_from_slice(&(samples.len() as u32).to_be_bytes());
+        trun.extend_from_slice(&data_offset.to_be_bytes()); // data_offset
+
+        for s in samples {
+            trun.extend_from_slice(&s.duration.to_be_bytes());
+            trun.extend_from_slice(&s.size.to_be_bytes());
+            let flags: u32 = if s.is_keyframe {
+                0x02000000 // keyframe
+            } else {
+                0x01010000 // non-keyframe
+            };
+            trun.extend_from_slice(&flags.to_be_bytes());
+        }
+        traf_body.extend_from_slice(&Self::wrap_box(&trun));
+
+        let mut traf = Vec::new();
+        traf.extend_from_slice(b"traf");
+        traf.extend_from_slice(&traf_body);
+        moof_body.extend_from_slice(&Self::wrap_box(&traf));
+
+        let mut moof = Vec::new();
+        moof.extend_from_slice(b"moof");
+        moof.extend_from_slice(&moof_body);
+        Self::wrap_box(&moof)
+    }
+
+    /// Build `mdat` (Media Data) box wrapping packet byte payloads.
+    pub fn build_mdat(packets: &[MediaPacket]) -> Vec<u8> {
+        let total_size: usize = packets.iter().map(|p| p.data.len()).sum();
+        let mut mdat = Vec::with_capacity(8 + total_size);
+        mdat.extend_from_slice(b"mdat");
+        for p in packets {
+            mdat.extend_from_slice(&p.data);
+        }
+        Self::wrap_box(&mdat)
+    }
+
+    /// Build a complete fMP4 segment (moof + mdat) from a list of media packets.
+    ///
+    /// This is a convenience method that builds proper `SampleInfo` entries from
+    /// the packets and calculates the correct `data_offset`.
+    pub fn build_segment(
+        sequence_number: u32,
+        track: &TrackInfo,
+        base_decode_time: u64,
+        packets: &[MediaPacket],
+    ) -> Vec<u8> {
+        let timescale = Self::timescale_for(track);
+
+        let samples: Vec<SampleInfo> = packets
+            .iter()
+            .map(|p| {
+                // If duration is 0 (unknown), use a sensible default:
+                // video: 1 frame at 24fps in track timescale
+                // audio: 1024 samples (common AAC frame size)
+                let duration = if p.duration > 0 {
+                    p.duration as u32
+                } else {
+                    match track.track_kind {
+                        TrackKind::Video => timescale / 24,
+                        TrackKind::Audio => 1024,
+                        TrackKind::Other => 1,
+                    }
+                };
+                SampleInfo {
+                    duration,
+                    size: p.data.len() as u32,
+                    is_keyframe: p.is_keyframe,
+                }
+            })
+            .collect();
+
+        // Build moof first with a placeholder data_offset of 0 to measure its size.
+        let moof_placeholder = Self::build_moof(sequence_number, track.id, base_decode_time, &samples, 0);
+        // data_offset = moof box size + 8 bytes for the mdat header
+        let data_offset = moof_placeholder.len() as u32 + 8;
+
+        // Rebuild with the correct data_offset
+        let moof = Self::build_moof(sequence_number, track.id, base_decode_time, &samples, data_offset);
+        let mdat = Self::build_mdat(packets);
+
+        let mut segment = Vec::with_capacity(moof.len() + mdat.len());
+        segment.extend_from_slice(&moof);
+        segment.extend_from_slice(&mdat);
+        segment
+    }
+
+    fn wrap_box(contents: &[u8]) -> Vec<u8> {
+        let size = (contents.len() + 4) as u32;
+        let mut res = Vec::with_capacity(size as usize);
+        res.extend_from_slice(&size.to_be_bytes());
+        res.extend_from_slice(contents);
+        res
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ftyp_box_magic() {
+        let ftyp = Fmp4Writer::build_ftyp();
+        assert_eq!(&ftyp[4..8], b"ftyp");
+        assert_eq!(&ftyp[8..12], b"iso8");
+    }
+
+    #[test]
+    fn test_moov_box_magic() {
+        let track = TrackInfo {
+            id: 1,
+            track_kind: TrackKind::Video,
+            codec: "H264".into(),
+            language: Some("eng".into()),
+            name: None,
+            sample_rate: None,
+            channels: None,
+            width: Some(1920),
+            height: Some(1080),
+            extra_data: vec![],
+        };
+        let moov = Fmp4Writer::build_moov(&track);
+        assert_eq!(&moov[4..8], b"moov");
+    }
+
+    #[test]
+    fn test_mdat_box_magic() {
+        let pkt = MediaPacket {
+            track_id: 1,
+            pts: 0,
+            dts: 0,
+            duration: 100,
+            is_keyframe: true,
+            data: vec![1, 2, 3, 4],
+        };
+        let mdat = Fmp4Writer::build_mdat(&[pkt]);
+        assert_eq!(&mdat[4..8], b"mdat");
+    }
+
+    #[test]
+    fn test_video_timescale_is_90000() {
+        let track = TrackInfo {
+            id: 1,
+            track_kind: TrackKind::Video,
+            codec: "H264".into(),
+            language: None,
+            name: None,
+            sample_rate: None,
+            channels: None,
+            width: Some(1920),
+            height: Some(1080),
+            extra_data: vec![],
+        };
+        assert_eq!(Fmp4Writer::timescale_for(&track), 90_000);
+    }
+
+    #[test]
+    fn test_audio_timescale_matches_sample_rate() {
+        let track = TrackInfo {
+            id: 2,
+            track_kind: TrackKind::Audio,
+            codec: "AAC".into(),
+            language: None,
+            name: None,
+            sample_rate: Some(48000),
+            channels: Some(2),
+            width: None,
+            height: None,
+            extra_data: vec![],
+        };
+        assert_eq!(Fmp4Writer::timescale_for(&track), 48_000);
+    }
+
+    #[test]
+    fn test_build_segment_correct_data_offset() {
+        let track = TrackInfo {
+            id: 1,
+            track_kind: TrackKind::Video,
+            codec: "H264".into(),
+            language: None,
+            name: None,
+            sample_rate: None,
+            channels: None,
+            width: Some(1920),
+            height: Some(1080),
+            extra_data: vec![],
+        };
+        let packets = vec![MediaPacket {
+            track_id: 1,
+            pts: 0,
+            dts: 0,
+            duration: 3750, // 90000 / 24
+            is_keyframe: true,
+            data: vec![0xAA; 100],
+        }];
+        let segment = Fmp4Writer::build_segment(1, &track, 0, &packets);
+        // Should contain both moof and mdat
+        assert!(segment.len() > 108); // moof + mdat header + 100 bytes of data
+        // Verify moof magic at offset 4
+        assert_eq!(&segment[4..8], b"moof");
+    }
+
+    #[test]
+    fn test_trun_flags_bits() {
+        let samples = vec![SampleInfo {
+            duration: 3000,
+            size: 100,
+            is_keyframe: true,
+        }];
+        let moof = Fmp4Writer::build_moof(1, 1, 0, &samples, 8);
+        // The trun box should be inside the moof. Search for "trun" magic.
+        let trun_pos = moof
+            .windows(4)
+            .position(|w| w == b"trun")
+            .expect("trun box not found");
+        // Flags are the 4 bytes after "trun": version (1 byte) + flags (3 bytes)
+        let flags_bytes = &moof[trun_pos + 4..trun_pos + 8];
+        assert_eq!(flags_bytes[0], 0x00); // version 0
+        // flags = 0x000701
+        assert_eq!(flags_bytes[1], 0x00);
+        assert_eq!(flags_bytes[2], 0x07);
+        assert_eq!(flags_bytes[3], 0x01);
+    }
+}

--- a/crates/vuio-core/src/media/remux/fmp4_writer.rs
+++ b/crates/vuio-core/src/media/remux/fmp4_writer.rs
@@ -1,11 +1,16 @@
 //! Pure Rust ISO BMFF / fMP4 (CMAF) box serializer.
 
-use super::mkv_demuxer::{MediaPacket, TrackInfo, TrackKind};
+use super::mkv_demuxer::{MediaPacket, TrackCodec, TrackInfo, TrackKind};
 
 pub struct SampleInfo {
     pub duration: u32,
     pub size: u32,
     pub is_keyframe: bool,
+    /// Presentation time minus decode time, in the track's output timescale. Zero for
+    /// every sample unless the source has B-frames (decode order != presentation
+    /// order) — without this, a player has no choice but to display frames in decode
+    /// order, since nothing else in a fragmented MP4 carries presentation timing.
+    pub composition_time_offset: i32,
 }
 
 pub struct Fmp4Writer;
@@ -217,57 +222,73 @@ impl Fmp4Writer {
         stsd.extend_from_slice(&[0; 4]); // version + flags
         stsd.extend_from_slice(&(1u32).to_be_bytes()); // entry count
 
-        let entry_box = if track.track_kind == TrackKind::Video {
-            let mut sample_entry = Vec::new();
-            sample_entry.extend_from_slice(b"avc1");
-            sample_entry.extend_from_slice(&[0; 6]); // reserved
-            sample_entry.extend_from_slice(&(1u16).to_be_bytes()); // data_reference_index
-            sample_entry.extend_from_slice(&[0; 16]); // pre_defined + reserved
-            sample_entry.extend_from_slice(&(track.width.unwrap_or(1920) as u16).to_be_bytes());
-            sample_entry.extend_from_slice(&(track.height.unwrap_or(1080) as u16).to_be_bytes());
-            sample_entry.extend_from_slice(&(0x00480000u32).to_be_bytes()); // horiz resolution 72 dpi
-            sample_entry.extend_from_slice(&(0x00480000u32).to_be_bytes()); // vert resolution 72 dpi
-            sample_entry.extend_from_slice(&[0; 4]); // reserved
-            sample_entry.extend_from_slice(&(1u16).to_be_bytes()); // frame_count = 1
-            sample_entry.extend_from_slice(&[0; 32]); // compressorname
-            sample_entry.extend_from_slice(&(0x0018u16).to_be_bytes()); // depth = 24
-            sample_entry.extend_from_slice(&(-1i16).to_be_bytes()); // pre_defined = -1
+        let entry_box = match track.codec_kind {
+            TrackCodec::Avc | TrackCodec::Hevc => {
+                let fourcc: &[u8; 4] = if track.codec_kind == TrackCodec::Hevc {
+                    b"hvc1"
+                } else {
+                    b"avc1"
+                };
+                let mut sample_entry = Vec::new();
+                sample_entry.extend_from_slice(fourcc);
+                sample_entry.extend_from_slice(&[0; 6]); // reserved
+                sample_entry.extend_from_slice(&(1u16).to_be_bytes()); // data_reference_index
+                sample_entry.extend_from_slice(&[0; 16]); // pre_defined + reserved
+                sample_entry
+                    .extend_from_slice(&(track.width.unwrap_or(1920) as u16).to_be_bytes());
+                sample_entry
+                    .extend_from_slice(&(track.height.unwrap_or(1080) as u16).to_be_bytes());
+                sample_entry.extend_from_slice(&(0x00480000u32).to_be_bytes()); // horiz resolution 72 dpi
+                sample_entry.extend_from_slice(&(0x00480000u32).to_be_bytes()); // vert resolution 72 dpi
+                sample_entry.extend_from_slice(&[0; 4]); // reserved
+                sample_entry.extend_from_slice(&(1u16).to_be_bytes()); // frame_count = 1
+                sample_entry.extend_from_slice(&[0; 32]); // compressorname
+                sample_entry.extend_from_slice(&(0x0018u16).to_be_bytes()); // depth = 24
+                sample_entry.extend_from_slice(&(-1i16).to_be_bytes()); // pre_defined = -1
 
-            if !track.extra_data.is_empty() {
-                let mut avcc = Vec::new();
-                avcc.extend_from_slice(b"avcC");
-                avcc.extend_from_slice(&track.extra_data);
-                sample_entry.extend_from_slice(&Self::wrap_box(&avcc));
+                if !track.extra_data.is_empty() {
+                    let config_box_name: &[u8; 4] = if track.codec_kind == TrackCodec::Hevc {
+                        b"hvcC"
+                    } else {
+                        b"avcC"
+                    };
+                    // Matroska's CodecPrivate for V_MPEG4/ISO/AVC and V_MPEGH/ISO/HEVC
+                    // *is* the AVC/HEVCDecoderConfigurationRecord, so the raw bytes can
+                    // be copied straight into the box body.
+                    let mut config = Vec::new();
+                    config.extend_from_slice(config_box_name);
+                    config.extend_from_slice(&track.extra_data);
+                    sample_entry.extend_from_slice(&Self::wrap_box(&config));
+                }
+                Self::wrap_box(&sample_entry)
             }
-            Self::wrap_box(&sample_entry)
-        } else {
-            let mut sample_entry = Vec::new();
-            sample_entry.extend_from_slice(b"mp4a");
-            sample_entry.extend_from_slice(&[0; 6]); // reserved
-            sample_entry.extend_from_slice(&(1u16).to_be_bytes()); // data_reference_index
-            sample_entry.extend_from_slice(&[0; 8]); // reserved
-            sample_entry
-                .extend_from_slice(&(track.channels.unwrap_or(2) as u16).to_be_bytes());
-            sample_entry.extend_from_slice(&(16u16).to_be_bytes()); // sample_size = 16
-            sample_entry.extend_from_slice(&[0; 4]); // pre_defined + reserved
-            sample_entry.extend_from_slice(
-                &(track.sample_rate.unwrap_or(44100) << 16).to_be_bytes(),
-            );
+            TrackCodec::Aac | TrackCodec::Unsupported => {
+                let mut sample_entry = Vec::new();
+                sample_entry.extend_from_slice(b"mp4a");
+                sample_entry.extend_from_slice(&[0; 6]); // reserved
+                sample_entry.extend_from_slice(&(1u16).to_be_bytes()); // data_reference_index
+                sample_entry.extend_from_slice(&[0; 8]); // reserved
+                sample_entry
+                    .extend_from_slice(&(track.channels.unwrap_or(2) as u16).to_be_bytes());
+                sample_entry.extend_from_slice(&(16u16).to_be_bytes()); // sample_size = 16
+                sample_entry.extend_from_slice(&[0; 4]); // pre_defined + reserved
+                sample_entry.extend_from_slice(
+                    &(track.sample_rate.unwrap_or(44100) << 16).to_be_bytes(),
+                );
 
-            if !track.extra_data.is_empty() {
-                let mut esds = Vec::new();
-                esds.extend_from_slice(b"esds");
-                esds.extend_from_slice(&[0; 4]); // version + flags
-                esds.extend_from_slice(&track.extra_data);
-                sample_entry.extend_from_slice(&Self::wrap_box(&esds));
+                if !track.extra_data.is_empty() {
+                    sample_entry
+                        .extend_from_slice(&Self::wrap_box(&Self::build_esds(&track.extra_data)));
+                }
+                Self::wrap_box(&sample_entry)
             }
-            Self::wrap_box(&sample_entry)
         };
         stsd.extend_from_slice(&entry_box);
         stbl_body.extend_from_slice(&Self::wrap_box(&stsd));
 
-        // Empty stts, stsc, stsz, stco for fMP4
-        for tag in &[b"stts", b"stsc", b"stsz", b"stco"] {
+        // Empty stts and stsc for fMP4 — both are version+flags(4) then a single
+        // entry_count(4) field.
+        for tag in &[b"stts", b"stsc"] {
             let mut empty_box = Vec::new();
             empty_box.extend_from_slice(*tag);
             empty_box.extend_from_slice(&[0; 4]); // version + flags
@@ -275,10 +296,73 @@ impl Fmp4Writer {
             stbl_body.extend_from_slice(&Self::wrap_box(&empty_box));
         }
 
+        // stsz has a different layout from the boxes above: version+flags(4), then
+        // sample_size(4) *and* sample_count(4) — two fields, not one. Treating it like
+        // the others silently drops sample_count, so a strict parser reads 4 bytes past
+        // the box's end into whatever follows it.
+        let mut stsz = Vec::new();
+        stsz.extend_from_slice(b"stsz");
+        stsz.extend_from_slice(&[0; 4]); // version + flags
+        stsz.extend_from_slice(&[0; 4]); // sample_size = 0 (entries are variable-size)
+        stsz.extend_from_slice(&[0; 4]); // sample_count = 0
+        stbl_body.extend_from_slice(&Self::wrap_box(&stsz));
+
+        // stco last, matching the order ffmpeg and other muxers emit.
+        let mut stco = Vec::new();
+        stco.extend_from_slice(b"stco");
+        stco.extend_from_slice(&[0; 4]); // version + flags
+        stco.extend_from_slice(&[0; 4]); // entry count = 0
+        stbl_body.extend_from_slice(&Self::wrap_box(&stco));
+
         let mut stbl = Vec::new();
         stbl.extend_from_slice(b"stbl");
         stbl.extend_from_slice(&stbl_body);
         Self::wrap_box(&stbl)
+    }
+
+    /// Build an MPEG-4 descriptor (ISO/IEC 14496-1 `Descriptor` syntax): a tag byte, a
+    /// length, then the content. Every descriptor built by `build_esds` is well under
+    /// 128 bytes, so a single, non-continued length byte always suffices.
+    fn build_descriptor(tag: u8, content: &[u8]) -> Vec<u8> {
+        debug_assert!(content.len() < 0x80, "descriptor too large for a 1-byte length");
+        let mut out = Vec::with_capacity(2 + content.len());
+        out.push(tag);
+        out.push(content.len() as u8);
+        out.extend_from_slice(content);
+        out
+    }
+
+    /// Build a spec-correct `esds` box wrapping a raw AAC `AudioSpecificConfig` in the
+    /// ES_Descriptor/DecoderConfigDescriptor/DecoderSpecificInfo structure MSE requires
+    /// (ISO/IEC 14496-1 §7.2.6.6) — an `esds` box cannot simply contain the raw config.
+    fn build_esds(audio_specific_config: &[u8]) -> Vec<u8> {
+        let decoder_specific_info = Self::build_descriptor(0x05, audio_specific_config);
+
+        let mut decoder_config_content = Vec::with_capacity(13 + decoder_specific_info.len());
+        decoder_config_content.push(0x40); // objectTypeIndication: MPEG-4 Audio (AAC)
+        decoder_config_content.push(0x15); // streamType=5 (audio) << 2 | upStream=0 | reserved=1
+        decoder_config_content.extend_from_slice(&[0, 0, 0]); // bufferSizeDB
+        decoder_config_content.extend_from_slice(&[0, 0, 0, 0]); // maxBitrate
+        decoder_config_content.extend_from_slice(&[0, 0, 0, 0]); // avgBitrate
+        decoder_config_content.extend_from_slice(&decoder_specific_info);
+        let decoder_config_descriptor = Self::build_descriptor(0x04, &decoder_config_content);
+
+        let sl_config_descriptor = Self::build_descriptor(0x06, &[0x02]);
+
+        let mut es_descriptor_content = Vec::with_capacity(
+            3 + decoder_config_descriptor.len() + sl_config_descriptor.len(),
+        );
+        es_descriptor_content.extend_from_slice(&[0, 0]); // ES_ID
+        es_descriptor_content.push(0x00); // flags: no dependsOn/URL/OCRstream
+        es_descriptor_content.extend_from_slice(&decoder_config_descriptor);
+        es_descriptor_content.extend_from_slice(&sl_config_descriptor);
+        let es_descriptor = Self::build_descriptor(0x03, &es_descriptor_content);
+
+        let mut esds = Vec::new();
+        esds.extend_from_slice(b"esds");
+        esds.extend_from_slice(&[0; 4]); // version + flags
+        esds.extend_from_slice(&es_descriptor);
+        esds
     }
 
     fn build_mvex(track_id: u32) -> Vec<u8> {
@@ -316,9 +400,19 @@ impl Fmp4Writer {
         let mut traf_body = Vec::new();
 
         // tfhd (Track Fragment Header)
+        //
+        // flags = default-base-is-moof (0x020000) — matches trun's data-offset, which
+        // is computed relative to the start of this moof. The previous value here,
+        // 0x000020, is a *different* flag (default-sample-flags-present) that
+        // requires a default_sample_flags field this box never wrote, so every parser
+        // strict enough to honor the flags it's told (ffmpeg, and apparently Chrome's
+        // MSE demuxer) read 4 bytes past the end of the box into tfdt's header,
+        // corrupting every fragment from here on — this was silently tolerated by
+        // ffprobe's lenient metadata-only parse, which is why it wasn't caught by
+        // that alone.
         let mut tfhd = Vec::new();
         tfhd.extend_from_slice(b"tfhd");
-        tfhd.extend_from_slice(&[0, 0, 0, 0x20]); // flags = default-base-is-moof
+        tfhd.extend_from_slice(&[0, 0x02, 0, 0]);
         tfhd.extend_from_slice(&track_id.to_be_bytes());
         traf_body.extend_from_slice(&Self::wrap_box(&tfhd));
 
@@ -331,12 +425,20 @@ impl Fmp4Writer {
         traf_body.extend_from_slice(&Self::wrap_box(&tfdt));
 
         // trun (Track Run)
+        //
+        // version 1 (signed sample_composition_time_offset) so B-frame content —
+        // where decode order != presentation order — can be reordered correctly by
+        // the player. Without this field, every sample's presentation time defaults
+        // to its decode time, and frames referencing data from *earlier* in
+        // presentation order than their decode position have nothing to correct that.
         let mut trun = Vec::new();
         trun.extend_from_slice(b"trun");
         // flags: data-offset-present (0x001) | sample-duration-present (0x100)
         //      | sample-size-present (0x200) | sample-flags-present (0x400)
-        // = 0x000701 in 24-bit flags field
-        trun.extend_from_slice(&[0, 0, 0x07, 0x01]);
+        //      | sample-composition-time-offsets-present (0x800)
+        // = 0x000F01 in 24-bit flags field
+        trun.push(1); // version 1
+        trun.extend_from_slice(&[0, 0x0F, 0x01]);
         trun.extend_from_slice(&(samples.len() as u32).to_be_bytes());
         trun.extend_from_slice(&data_offset.to_be_bytes()); // data_offset
 
@@ -349,6 +451,7 @@ impl Fmp4Writer {
                 0x01010000 // non-keyframe
             };
             trun.extend_from_slice(&flags.to_be_bytes());
+            trun.extend_from_slice(&s.composition_time_offset.to_be_bytes());
         }
         traf_body.extend_from_slice(&Self::wrap_box(&trun));
 
@@ -378,36 +481,54 @@ impl Fmp4Writer {
     ///
     /// This is a convenience method that builds proper `SampleInfo` entries from
     /// the packets and calculates the correct `data_offset`.
+    ///
+    /// `packets` must be in decode order with decode timestamps already resolved (see
+    /// `mkv_demuxer::derive_decode_timestamps`): sample durations and the fragment's
+    /// base decode time are taken from `dts`, so that the decode timeline stays
+    /// monotonic, while `pts - dts` supplies each sample's composition offset.
+    /// `fallback_base_decode_time` is used only when `packets` is empty.
     pub fn build_segment(
         sequence_number: u32,
         track: &TrackInfo,
-        base_decode_time: u64,
+        fallback_base_decode_time: u64,
         packets: &[MediaPacket],
     ) -> Vec<u8> {
         let timescale = Self::timescale_for(track);
 
         let samples: Vec<SampleInfo> = packets
             .iter()
-            .map(|p| {
-                // If duration is 0 (unknown), use a sensible default:
-                // video: 1 frame at 24fps in track timescale
-                // audio: 1024 samples (common AAC frame size)
-                let duration = if p.duration > 0 {
-                    p.duration as u32
-                } else {
-                    match track.track_kind {
-                        TrackKind::Video => timescale / 24,
+            .enumerate()
+            .map(|(i, p)| {
+                // Space samples by the gap to the next decode timestamp, so the decode
+                // timeline this fragment declares matches the one the timestamps
+                // describe. The container's own per-frame duration is the fallback for
+                // the final sample (which has no successor here) and for sources that
+                // don't carry usable timestamps at all.
+                let duration = packets
+                    .get(i + 1)
+                    .map(|next| next.dts.saturating_sub(p.dts))
+                    .filter(|gap| *gap > 0)
+                    .or(Some(p.duration).filter(|d| *d > 0))
+                    .unwrap_or(match track.track_kind {
+                        // 1 frame at 24fps in the track timescale
+                        TrackKind::Video => u64::from(timescale / 24),
+                        // 1024 samples, the common AAC frame size
                         TrackKind::Audio => 1024,
                         TrackKind::Other => 1,
-                    }
-                };
+                    }) as u32;
                 SampleInfo {
                     duration,
                     size: p.data.len() as u32,
                     is_keyframe: p.is_keyframe,
+                    composition_time_offset: (p.pts as i64 - p.dts as i64) as i32,
                 }
             })
             .collect();
+
+        let base_decode_time = packets
+            .first()
+            .map(|p| p.dts)
+            .unwrap_or(fallback_base_decode_time);
 
         // Build moof first with a placeholder data_offset of 0 to measure its size.
         let moof_placeholder = Self::build_moof(sequence_number, track.id, base_decode_time, &samples, 0);
@@ -450,6 +571,7 @@ mod tests {
             id: 1,
             track_kind: TrackKind::Video,
             codec: "H264".into(),
+            codec_kind: TrackCodec::Avc,
             language: Some("eng".into()),
             name: None,
             sample_rate: None,
@@ -482,6 +604,7 @@ mod tests {
             id: 1,
             track_kind: TrackKind::Video,
             codec: "H264".into(),
+            codec_kind: TrackCodec::Avc,
             language: None,
             name: None,
             sample_rate: None,
@@ -499,6 +622,7 @@ mod tests {
             id: 2,
             track_kind: TrackKind::Audio,
             codec: "AAC".into(),
+            codec_kind: TrackCodec::Aac,
             language: None,
             name: None,
             sample_rate: Some(48000),
@@ -516,6 +640,7 @@ mod tests {
             id: 1,
             track_kind: TrackKind::Video,
             codec: "H264".into(),
+            codec_kind: TrackCodec::Avc,
             language: None,
             name: None,
             sample_rate: None,
@@ -545,6 +670,7 @@ mod tests {
             duration: 3000,
             size: 100,
             is_keyframe: true,
+            composition_time_offset: 0,
         }];
         let moof = Fmp4Writer::build_moof(1, 1, 0, &samples, 8);
         // The trun box should be inside the moof. Search for "trun" magic.
@@ -554,10 +680,170 @@ mod tests {
             .expect("trun box not found");
         // Flags are the 4 bytes after "trun": version (1 byte) + flags (3 bytes)
         let flags_bytes = &moof[trun_pos + 4..trun_pos + 8];
-        assert_eq!(flags_bytes[0], 0x00); // version 0
-        // flags = 0x000701
+        // version 1 — required for *signed* sample_composition_time_offset, so
+        // B-frame content (decode order != presentation order) reorders correctly.
+        assert_eq!(flags_bytes[0], 0x01);
+        // flags = 0x000F01 (adds composition-time-offsets-present, 0x800, to the
+        // previous 0x000701)
         assert_eq!(flags_bytes[1], 0x00);
-        assert_eq!(flags_bytes[2], 0x07);
+        assert_eq!(flags_bytes[2], 0x0F);
         assert_eq!(flags_bytes[3], 0x01);
+    }
+
+    #[test]
+    fn test_tfhd_flags_is_default_base_is_moof_with_no_extra_fields() {
+        // Regression test: this box previously declared flags = 0x000020
+        // (default-sample-flags-present) while a comment claimed
+        // default-base-is-moof (0x020000), and never wrote the default_sample_flags
+        // field that 0x000020 promises. A strict parser (ffmpeg, Chrome's MSE
+        // demuxer) reads 4 bytes past the box's declared end as a result, corrupting
+        // every fragment — invisible to ffprobe's lenient metadata-only parse, which
+        // is why this needs its own targeted check rather than relying on ffprobe.
+        let samples = vec![SampleInfo {
+            duration: 3000,
+            size: 100,
+            is_keyframe: true,
+            composition_time_offset: 0,
+        }];
+        let moof = Fmp4Writer::build_moof(1, 7, 0, &samples, 8);
+        let tfhd_pos = moof.windows(4).position(|w| w == b"tfhd").expect("tfhd box not found");
+        let box_size = u32::from_be_bytes(moof[tfhd_pos - 4..tfhd_pos].try_into().unwrap());
+        let flags_bytes = &moof[tfhd_pos + 4..tfhd_pos + 8];
+        assert_eq!(flags_bytes, &[0x00, 0x02, 0x00, 0x00], "flags must be default-base-is-moof (0x020000)");
+        // size(4) + "tfhd"(4) + version+flags(4) + track_id(4) = 16, with nothing else,
+        // since none of the optional-field flag bits are set.
+        assert_eq!(box_size, 16);
+        let track_id_bytes = &moof[tfhd_pos + 8..tfhd_pos + 12];
+        assert_eq!(track_id_bytes, &7u32.to_be_bytes());
+    }
+
+    #[test]
+    fn test_stsz_has_sample_size_and_sample_count_fields() {
+        // Regression test: stsz has a different layout from stts/stsc/stco (it has
+        // *two* 4-byte fields after version+flags, not one) — treating all four
+        // boxes identically silently dropped the sample_count field.
+        let track = TrackInfo {
+            id: 1,
+            track_kind: TrackKind::Video,
+            codec: "H264".into(),
+            codec_kind: TrackCodec::Avc,
+            language: None,
+            name: None,
+            sample_rate: None,
+            channels: None,
+            width: Some(1920),
+            height: Some(1080),
+            extra_data: vec![],
+        };
+        let moov = Fmp4Writer::build_moov(&track);
+        let stsz_pos = moov.windows(4).position(|w| w == b"stsz").expect("stsz box not found");
+        let box_size = u32::from_be_bytes(moov[stsz_pos - 4..stsz_pos].try_into().unwrap());
+        // size(4) + "stsz"(4) + version+flags(4) + sample_size(4) + sample_count(4) = 20.
+        assert_eq!(box_size, 20);
+    }
+
+    #[test]
+    fn test_avc_stsd_writes_avc1_and_avcc() {
+        let track = TrackInfo {
+            id: 1,
+            track_kind: TrackKind::Video,
+            codec: "H.264".into(),
+            codec_kind: TrackCodec::Avc,
+            language: None,
+            name: None,
+            sample_rate: None,
+            channels: None,
+            width: Some(1920),
+            height: Some(1080),
+            extra_data: vec![0x01, 0x64, 0x00, 0x28, 0xAB, 0xCD], // fake AVCDecoderConfigurationRecord
+        };
+        let moov = Fmp4Writer::build_moov(&track);
+        assert!(moov.windows(4).any(|w| w == b"avc1"));
+        assert!(moov.windows(4).any(|w| w == b"avcC"));
+        assert!(!moov.windows(4).any(|w| w == b"hvc1"));
+        // The raw CodecPrivate bytes must be copied verbatim into avcC.
+        assert!(moov.windows(track.extra_data.len()).any(|w| w == track.extra_data.as_slice()));
+    }
+
+    #[test]
+    fn test_hevc_stsd_writes_hvc1_and_hvcc() {
+        let track = TrackInfo {
+            id: 1,
+            track_kind: TrackKind::Video,
+            codec: "HEVC".into(),
+            codec_kind: TrackCodec::Hevc,
+            language: None,
+            name: None,
+            sample_rate: None,
+            channels: None,
+            width: Some(3840),
+            height: Some(2160),
+            extra_data: vec![0x01, 0x02, 0x20, 0x00, 0x00, 0x00], // fake HEVCDecoderConfigurationRecord
+        };
+        let moov = Fmp4Writer::build_moov(&track);
+        assert!(moov.windows(4).any(|w| w == b"hvc1"));
+        assert!(moov.windows(4).any(|w| w == b"hvcC"));
+        assert!(!moov.windows(4).any(|w| w == b"avc1"));
+    }
+
+    #[test]
+    fn test_avc_without_extra_data_omits_avcc_box() {
+        let track = TrackInfo {
+            id: 1,
+            track_kind: TrackKind::Video,
+            codec: "H.264".into(),
+            codec_kind: TrackCodec::Avc,
+            language: None,
+            name: None,
+            sample_rate: None,
+            channels: None,
+            width: Some(1920),
+            height: Some(1080),
+            extra_data: vec![],
+        };
+        let moov = Fmp4Writer::build_moov(&track);
+        assert!(moov.windows(4).any(|w| w == b"avc1"));
+        assert!(!moov.windows(4).any(|w| w == b"avcC"));
+    }
+
+    #[test]
+    fn test_aac_stsd_esds_wraps_audio_specific_config() {
+        let audio_specific_config = vec![0x11, 0x90]; // AAC-LC, 48kHz, stereo
+        let track = TrackInfo {
+            id: 2,
+            track_kind: TrackKind::Audio,
+            codec: "AAC".into(),
+            codec_kind: TrackCodec::Aac,
+            language: None,
+            name: None,
+            sample_rate: Some(48_000),
+            channels: Some(2),
+            width: None,
+            height: None,
+            extra_data: audio_specific_config.clone(),
+        };
+        let moov = Fmp4Writer::build_moov(&track);
+        assert!(moov.windows(4).any(|w| w == b"mp4a"));
+        assert!(moov.windows(4).any(|w| w == b"esds"));
+        // The esds body must be a proper ES_Descriptor tree (tag 0x03), not the raw
+        // AudioSpecificConfig dumped directly into the box.
+        let esds_pos = moov.windows(4).position(|w| w == b"esds").unwrap();
+        assert_eq!(moov[esds_pos + 8], 0x03, "esds body must start with an ES_Descriptor tag");
+        // The raw AudioSpecificConfig must still be present, nested inside DecoderSpecificInfo.
+        assert!(moov
+            .windows(audio_specific_config.len())
+            .any(|w| w == audio_specific_config.as_slice()));
+    }
+
+    #[test]
+    fn test_esds_descriptor_tags_and_lengths() {
+        let esds = Fmp4Writer::build_esds(&[0x11, 0x90]);
+        assert_eq!(&esds[0..4], b"esds");
+        assert_eq!(esds[8], 0x03, "ES_Descriptor tag");
+        let es_descriptor_len = esds[9] as usize;
+        assert_eq!(esds.len(), 10 + es_descriptor_len);
+        // DecoderConfigDescriptor (tag 0x04) follows the 3-byte ES_ID+flags header.
+        assert_eq!(esds[13], 0x04, "DecoderConfigDescriptor tag");
+        assert_eq!(esds[15], 0x40, "objectTypeIndication must be MPEG-4 Audio (AAC)");
     }
 }

--- a/crates/vuio-core/src/media/remux/hls.rs
+++ b/crates/vuio-core/src/media/remux/hls.rs
@@ -1,21 +1,33 @@
 //! HLS playlist generator supporting RFC 8216 multi-audio tracks.
 
-use super::mkv_demuxer::{TrackInfo, TrackKind};
+use super::mkv_demuxer::{browser_audio_tracks, browser_video_track, TrackCodec, TrackInfo};
 
 pub struct HlsGenerator;
 
 impl HlsGenerator {
     /// Generate HLS Master Playlist (`master.m3u8`) for an MKV file containing multi-audio tracks.
+    ///
+    /// Only tracks this remuxer can actually pass through into fMP4 are offered: a video
+    /// track must be AVC/HEVC, and only AAC audio tracks are listed as selectable
+    /// renditions (E-AC-3/AC-3/DTS/TrueHD/etc. audio has no in-browser decoder, so
+    /// serving it would just be a silent/broken rendition).
     pub fn build_master_playlist(_media_id: &str, tracks: &[TrackInfo]) -> String {
+        let Some(video_track) = browser_video_track(tracks) else {
+            // No browser-playable video track: a variant-less master playlist fails
+            // hls.js's manifest parse, which routes the player to its existing
+            // "can't play this" fallback instead of trying to decode something that
+            // can't work.
+            return "#EXTM3U\n#EXT-X-VERSION:6\n".to_string();
+        };
+
+        let audio_tracks = browser_audio_tracks(tracks);
+
         let mut playlist = String::new();
         playlist.push_str("#EXTM3U\n");
         playlist.push_str("#EXT-X-VERSION:6\n");
         playlist.push_str("#EXT-X-INDEPENDENT-SEGMENTS\n\n");
 
-        let audio_tracks: Vec<&TrackInfo> = tracks
-            .iter()
-            .filter(|t| t.track_kind == TrackKind::Audio)
-            .collect();
+        let video_codec = video_codec_string(video_track);
 
         if !audio_tracks.is_empty() {
             for (idx, track) in audio_tracks.iter().enumerate() {
@@ -32,46 +44,61 @@ impl HlsGenerator {
                 ));
             }
             playlist.push('\n');
-            playlist.push_str(
-                "#EXT-X-STREAM-INF:BANDWIDTH=5000000,CODECS=\"avc1.640028,mp4a.40.2\",AUDIO=\"audio\"\n",
-            );
+            let audio_codec = aac_codec_string(&audio_tracks[0].extra_data);
+            playlist.push_str(&format!(
+                "#EXT-X-STREAM-INF:BANDWIDTH=5000000,CODECS=\"{},{}\",AUDIO=\"audio\"\n",
+                video_codec, audio_codec
+            ));
             playlist.push_str("video/index.m3u8\n");
         } else {
-            // Video-only fallback
-            playlist.push_str(
-                "#EXT-X-STREAM-INF:BANDWIDTH=5000000,CODECS=\"avc1.640028\"\n",
-            );
+            // Video-only: either the file has no audio, or none of its audio tracks
+            // are browser-playable.
+            playlist.push_str(&format!(
+                "#EXT-X-STREAM-INF:BANDWIDTH=5000000,CODECS=\"{}\"\n",
+                video_codec
+            ));
             playlist.push_str("video/index.m3u8\n");
         }
 
         playlist
     }
 
-    /// Generate HLS Media Playlist (`index.m3u8`) for video or audio stream.
-    pub fn build_media_playlist(
-        init_segment_name: &str,
-        segment_count: usize,
-        target_duration_secs: u32,
-    ) -> String {
+    /// Generate an HLS Media Playlist (`index.m3u8`) for a video or audio rendition.
+    ///
+    /// Every rendition's init segment and segments live alongside its own playlist
+    /// (`init.mp4`, `segment/{n}`), so this is identical for video and audio callers.
+    pub fn build_media_playlist(total_duration_secs: f64, segment_duration_secs: u32) -> String {
+        let segment_duration_secs = segment_duration_secs.max(1);
+        let total_duration_secs = total_duration_secs.max(0.0);
+        let segment_count = (total_duration_secs / segment_duration_secs as f64)
+            .ceil()
+            .max(1.0) as usize;
+
         let mut playlist = String::new();
         playlist.push_str("#EXTM3U\n");
         playlist.push_str("#EXT-X-VERSION:6\n");
         playlist.push_str(&format!(
             "#EXT-X-TARGETDURATION:{}\n",
-            target_duration_secs
+            segment_duration_secs
         ));
         playlist.push_str("#EXT-X-MEDIA-SEQUENCE:0\n");
         playlist.push_str("#EXT-X-PLAYLIST-TYPE:VOD\n");
-        playlist.push_str(&format!(
-            "#EXT-X-MAP:URI=\"{}\"\n\n",
-            init_segment_name
-        ));
+        playlist.push_str("#EXT-X-MAP:URI=\"init.mp4\"\n\n");
 
+        let mut remaining = total_duration_secs;
         for i in 0..segment_count {
-            playlist.push_str(&format!(
-                "#EXTINF:{:.3},\nsegment/{}\n",
-                target_duration_secs as f64, i
-            ));
+            // Every segment is `segment_duration_secs` except the last, which is
+            // whatever real time is left — declaring the nominal duration for a
+            // shorter final segment drifts the reported vs. actual timeline and can
+            // make players stall waiting for content that was never coming.
+            let this_duration = if i + 1 == segment_count {
+                remaining.max(0.0)
+            } else {
+                segment_duration_secs as f64
+            };
+            remaining -= this_duration;
+
+            playlist.push_str(&format!("#EXTINF:{:.3},\nsegment/{}\n", this_duration, i));
         }
 
         playlist.push_str("#EXT-X-ENDLIST\n");
@@ -79,49 +106,74 @@ impl HlsGenerator {
     }
 }
 
+/// Derive an `avc1.PPCCLL`/generic `hvc1...` CODECS string. hls.js/MSE only use this for
+/// a `MediaSource.isTypeSupported` capability pre-check — actual decode relies on the
+/// real VPS/SPS/PPS carried in the init segment's `avcC`/`hvcC` box, not this string.
+fn video_codec_string(track: &TrackInfo) -> String {
+    match track.codec_kind {
+        TrackCodec::Avc if track.extra_data.len() >= 4 => format!(
+            "avc1.{:02x}{:02x}{:02x}",
+            track.extra_data[1], track.extra_data[2], track.extra_data[3]
+        ),
+        TrackCodec::Hevc => "hvc1.1.6.L93.B0".to_string(),
+        _ => "avc1.640028".to_string(),
+    }
+}
+
+/// Derive an `mp4a.40.{audioObjectType}` CODECS string from the leading bits of the raw
+/// AAC `AudioSpecificConfig` (audioObjectType is the top 5 bits of the first byte).
+fn aac_codec_string(extra_data: &[u8]) -> String {
+    let audio_object_type = extra_data
+        .first()
+        .map(|b| b >> 3)
+        .filter(|&t| t != 0)
+        .unwrap_or(2); // 2 == AAC-LC, the common/safe default.
+    format!("mp4a.40.{}", audio_object_type)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use super::super::mkv_demuxer::TrackKind;
+
+    fn video_track(codec_kind: TrackCodec) -> TrackInfo {
+        TrackInfo {
+            id: 1,
+            track_kind: TrackKind::Video,
+            codec: "H264".into(),
+            codec_kind,
+            language: None,
+            name: None,
+            sample_rate: None,
+            channels: None,
+            width: Some(1920),
+            height: Some(1080),
+            extra_data: vec![0x01, 0x64, 0x00, 0x28],
+        }
+    }
+
+    fn audio_track(id: u32, codec_kind: TrackCodec, name: &str, lang: &str) -> TrackInfo {
+        TrackInfo {
+            id,
+            track_kind: TrackKind::Audio,
+            codec: "AAC".into(),
+            codec_kind,
+            language: Some(lang.into()),
+            name: Some(name.into()),
+            sample_rate: Some(48000),
+            channels: Some(if codec_kind == TrackCodec::Aac { 2 } else { 6 }),
+            width: None,
+            height: None,
+            extra_data: vec![0x11, 0x90],
+        }
+    }
 
     #[test]
     fn test_master_playlist_multi_audio() {
         let tracks = vec![
-            TrackInfo {
-                id: 1,
-                track_kind: TrackKind::Video,
-                codec: "H264".into(),
-                language: None,
-                name: None,
-                sample_rate: None,
-                channels: None,
-                width: Some(1920),
-                height: Some(1080),
-                extra_data: vec![],
-            },
-            TrackInfo {
-                id: 2,
-                track_kind: TrackKind::Audio,
-                codec: "AAC".into(),
-                language: Some("eng".into()),
-                name: Some("English".into()),
-                sample_rate: Some(48000),
-                channels: Some(6),
-                width: None,
-                height: None,
-                extra_data: vec![],
-            },
-            TrackInfo {
-                id: 3,
-                track_kind: TrackKind::Audio,
-                codec: "AAC".into(),
-                language: Some("spa".into()),
-                name: Some("Spanish".into()),
-                sample_rate: Some(48000),
-                channels: Some(2),
-                width: None,
-                height: None,
-                extra_data: vec![],
-            },
+            video_track(TrackCodec::Avc),
+            audio_track(2, TrackCodec::Aac, "English", "eng"),
+            audio_track(3, TrackCodec::Aac, "Spanish", "spa"),
         ];
 
         let master = HlsGenerator::build_master_playlist("test-id", &tracks);
@@ -130,5 +182,46 @@ mod tests {
         assert!(master.contains("NAME=\"Spanish\""));
         assert!(master.contains("audio/0/index.m3u8"));
         assert!(master.contains("audio/1/index.m3u8"));
+    }
+
+    #[test]
+    fn test_master_playlist_excludes_unsupported_audio_codecs() {
+        // Mirrors a real WEB-DL release: AVC video with only E-AC-3/AC-3 audio tracks —
+        // none of those tracks can be decoded in-browser, so none should be offered.
+        let tracks = vec![
+            video_track(TrackCodec::Avc),
+            audio_track(2, TrackCodec::Unsupported, "5.1 Atmos", "eng"),
+            audio_track(3, TrackCodec::Unsupported, "Stereo", "eng"),
+        ];
+
+        let master = HlsGenerator::build_master_playlist("test-id", &tracks);
+        assert!(!master.contains("#EXT-X-MEDIA:TYPE=AUDIO"));
+        assert!(!master.contains("AUDIO=\"audio\""));
+        assert!(master.contains("video/index.m3u8"));
+    }
+
+    #[test]
+    fn test_master_playlist_no_supported_video_is_variant_less() {
+        let tracks = vec![video_track(TrackCodec::Unsupported)];
+        let master = HlsGenerator::build_master_playlist("test-id", &tracks);
+        assert!(!master.contains("#EXT-X-STREAM-INF"));
+    }
+
+    #[test]
+    fn test_media_playlist_final_segment_uses_real_remainder() {
+        // 10 seconds of content at a 4-second target: 4, 4, then a 2-second remainder —
+        // not another 4-second entry that overruns the real content.
+        let playlist = HlsGenerator::build_media_playlist(10.0, 4);
+        assert!(playlist.contains("#EXTINF:4.000,\nsegment/0\n"));
+        assert!(playlist.contains("#EXTINF:4.000,\nsegment/1\n"));
+        assert!(playlist.contains("#EXTINF:2.000,\nsegment/2\n"));
+        assert!(!playlist.contains("segment/3"));
+        assert!(playlist.contains("#EXT-X-MAP:URI=\"init.mp4\""));
+    }
+
+    #[test]
+    fn test_video_codec_string_uses_real_avcc_bytes() {
+        let track = video_track(TrackCodec::Avc);
+        assert_eq!(video_codec_string(&track), "avc1.640028");
     }
 }

--- a/crates/vuio-core/src/media/remux/hls.rs
+++ b/crates/vuio-core/src/media/remux/hls.rs
@@ -1,0 +1,134 @@
+//! HLS playlist generator supporting RFC 8216 multi-audio tracks.
+
+use super::mkv_demuxer::{TrackInfo, TrackKind};
+
+pub struct HlsGenerator;
+
+impl HlsGenerator {
+    /// Generate HLS Master Playlist (`master.m3u8`) for an MKV file containing multi-audio tracks.
+    pub fn build_master_playlist(_media_id: &str, tracks: &[TrackInfo]) -> String {
+        let mut playlist = String::new();
+        playlist.push_str("#EXTM3U\n");
+        playlist.push_str("#EXT-X-VERSION:6\n");
+        playlist.push_str("#EXT-X-INDEPENDENT-SEGMENTS\n\n");
+
+        let audio_tracks: Vec<&TrackInfo> = tracks
+            .iter()
+            .filter(|t| t.track_kind == TrackKind::Audio)
+            .collect();
+
+        if !audio_tracks.is_empty() {
+            for (idx, track) in audio_tracks.iter().enumerate() {
+                let name = track
+                    .name
+                    .clone()
+                    .unwrap_or_else(|| format!("Audio Track {}", idx + 1));
+                let lang = track.language.as_deref().unwrap_or("und");
+                let is_default = if idx == 0 { "YES" } else { "NO" };
+
+                playlist.push_str(&format!(
+                    "#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID=\"audio\",NAME=\"{}\",DEFAULT={},AUTOSELECT=YES,LANGUAGE=\"{}\",URI=\"audio/{}/index.m3u8\"\n",
+                    name, is_default, lang, idx
+                ));
+            }
+            playlist.push('\n');
+            playlist.push_str(
+                "#EXT-X-STREAM-INF:BANDWIDTH=5000000,CODECS=\"avc1.640028,mp4a.40.2\",AUDIO=\"audio\"\n",
+            );
+            playlist.push_str("video/index.m3u8\n");
+        } else {
+            // Video-only fallback
+            playlist.push_str(
+                "#EXT-X-STREAM-INF:BANDWIDTH=5000000,CODECS=\"avc1.640028\"\n",
+            );
+            playlist.push_str("video/index.m3u8\n");
+        }
+
+        playlist
+    }
+
+    /// Generate HLS Media Playlist (`index.m3u8`) for video or audio stream.
+    pub fn build_media_playlist(
+        init_segment_name: &str,
+        segment_count: usize,
+        target_duration_secs: u32,
+    ) -> String {
+        let mut playlist = String::new();
+        playlist.push_str("#EXTM3U\n");
+        playlist.push_str("#EXT-X-VERSION:6\n");
+        playlist.push_str(&format!(
+            "#EXT-X-TARGETDURATION:{}\n",
+            target_duration_secs
+        ));
+        playlist.push_str("#EXT-X-MEDIA-SEQUENCE:0\n");
+        playlist.push_str("#EXT-X-PLAYLIST-TYPE:VOD\n");
+        playlist.push_str(&format!(
+            "#EXT-X-MAP:URI=\"{}\"\n\n",
+            init_segment_name
+        ));
+
+        for i in 0..segment_count {
+            playlist.push_str(&format!(
+                "#EXTINF:{:.3},\nsegment/{}\n",
+                target_duration_secs as f64, i
+            ));
+        }
+
+        playlist.push_str("#EXT-X-ENDLIST\n");
+        playlist
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_master_playlist_multi_audio() {
+        let tracks = vec![
+            TrackInfo {
+                id: 1,
+                track_kind: TrackKind::Video,
+                codec: "H264".into(),
+                language: None,
+                name: None,
+                sample_rate: None,
+                channels: None,
+                width: Some(1920),
+                height: Some(1080),
+                extra_data: vec![],
+            },
+            TrackInfo {
+                id: 2,
+                track_kind: TrackKind::Audio,
+                codec: "AAC".into(),
+                language: Some("eng".into()),
+                name: Some("English".into()),
+                sample_rate: Some(48000),
+                channels: Some(6),
+                width: None,
+                height: None,
+                extra_data: vec![],
+            },
+            TrackInfo {
+                id: 3,
+                track_kind: TrackKind::Audio,
+                codec: "AAC".into(),
+                language: Some("spa".into()),
+                name: Some("Spanish".into()),
+                sample_rate: Some(48000),
+                channels: Some(2),
+                width: None,
+                height: None,
+                extra_data: vec![],
+            },
+        ];
+
+        let master = HlsGenerator::build_master_playlist("test-id", &tracks);
+        assert!(master.contains("#EXT-X-MEDIA:TYPE=AUDIO"));
+        assert!(master.contains("NAME=\"English\""));
+        assert!(master.contains("NAME=\"Spanish\""));
+        assert!(master.contains("audio/0/index.m3u8"));
+        assert!(master.contains("audio/1/index.m3u8"));
+    }
+}

--- a/crates/vuio-core/src/media/remux/mkv_demuxer.rs
+++ b/crates/vuio-core/src/media/remux/mkv_demuxer.rs
@@ -1,0 +1,227 @@
+//! Matroska (.mkv) track inspection and sample packet demuxing via Symphonia.
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TrackKind {
+    Video,
+    Audio,
+    Other,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TrackInfo {
+    pub id: u32,
+    pub track_kind: TrackKind,
+    pub codec: String,
+    pub language: Option<String>,
+    pub name: Option<String>,
+    pub sample_rate: Option<u32>,
+    pub channels: Option<u8>,
+    pub width: Option<u32>,
+    pub height: Option<u32>,
+    pub extra_data: Vec<u8>,
+}
+
+/// Container-agnostic media packet with plain integer timestamps.
+///
+/// Timestamp units depend on the source container's timescale; callers must
+/// know (or query) the timescale to interpret `pts`/`dts`/`duration` correctly.
+#[derive(Debug, Clone)]
+pub struct MediaPacket {
+    pub track_id: u32,
+    pub pts: u64,
+    pub dts: u64,
+    pub duration: u64,
+    pub is_keyframe: bool,
+    pub data: Vec<u8>,
+}
+
+/// File-level metadata extracted during probing.
+#[derive(Debug, Clone)]
+pub struct FileInfo {
+    pub tracks: Vec<TrackInfo>,
+    /// Total duration of the file in seconds (if available from the container).
+    pub duration_secs: Option<f64>,
+}
+
+pub struct MkvDemuxer;
+
+impl MkvDemuxer {
+    /// Inspect tracks in a media file, returning track metadata and file-level
+    /// info such as duration.
+    #[cfg(feature = "casting")]
+    pub fn inspect(path: &Path) -> Result<FileInfo> {
+        use symphonia::core::formats::probe::Hint;
+        use symphonia::core::formats::FormatOptions;
+        use symphonia::core::io::MediaSourceStream;
+        use symphonia::core::meta::MetadataOptions;
+
+        let file = std::fs::File::open(path)
+            .with_context(|| format!("Failed to open MKV file: {}", path.display()))?;
+        let stream = MediaSourceStream::new(Box::new(file), Default::default());
+
+        let mut hint = Hint::new();
+        if let Some(ext) = path.extension().and_then(|e| e.to_str()) {
+            hint.with_extension(ext);
+        }
+
+        let format = symphonia::default::get_probe()
+            .probe(
+                &hint,
+                stream,
+                FormatOptions::default(),
+                MetadataOptions::default(),
+            )
+            .with_context(|| format!("Failed to probe media file: {}", path.display()))?;
+
+        let mut tracks = Vec::new();
+
+        // Try to get file duration from the first track's time base + n_frames,
+        // or from the format's default track.
+        let duration_secs: Option<f64> = None;
+
+        for t in format.tracks() {
+            let params = match t.codec_params.as_ref() {
+                Some(p) => p,
+                None => continue,
+            };
+
+            let kind = if params.video().is_some() {
+                TrackKind::Video
+            } else if params.audio().is_some() {
+                TrackKind::Audio
+            } else {
+                TrackKind::Other
+            };
+
+            if kind == TrackKind::Other {
+                continue;
+            }
+
+            let codec = format!("{:?}", params);
+            let sample_rate = params.audio().and_then(|a| a.sample_rate);
+            let channels = params
+                .audio()
+                .and_then(|a| a.channels.clone())
+                .map(|c| c.count() as u8);
+            let width = params.video().and_then(|v| v.width).map(u32::from);
+            let height = params.video().and_then(|v| v.height).map(u32::from);
+            let extra_data = Vec::new();
+
+            let language = t.language.clone();
+
+            tracks.push(TrackInfo {
+                id: t.id,
+                track_kind: kind,
+                codec,
+                language,
+                name: None,
+                sample_rate,
+                channels,
+                width,
+                height,
+                extra_data,
+            });
+        }
+
+        Ok(FileInfo {
+            tracks,
+            duration_secs,
+        })
+    }
+
+    #[cfg(not(feature = "casting"))]
+    pub fn inspect(_path: &Path) -> Result<FileInfo> {
+        Err(anyhow::anyhow!("Casting/Symphonia feature not enabled"))
+    }
+
+    /// Legacy convenience wrapper — returns just the track list.
+    pub fn inspect_tracks(path: &Path) -> Result<Vec<TrackInfo>> {
+        Self::inspect(path).map(|fi| fi.tracks)
+    }
+
+    /// Extract packets for a given track, skipping the first `skip_packets` and
+    /// returning at most `max_packets`.
+    #[cfg(feature = "casting")]
+    pub fn extract_track_packets(
+        path: &Path,
+        target_track_id: u32,
+        skip_packets: usize,
+        max_packets: usize,
+    ) -> Result<Vec<MediaPacket>> {
+        use symphonia::core::formats::probe::Hint;
+        use symphonia::core::formats::FormatOptions;
+        use symphonia::core::io::MediaSourceStream;
+        use symphonia::core::meta::MetadataOptions;
+
+        let file = std::fs::File::open(path)?;
+        let stream = MediaSourceStream::new(Box::new(file), Default::default());
+
+        let mut hint = Hint::new();
+        if let Some(ext) = path.extension().and_then(|e| e.to_str()) {
+            hint.with_extension(ext);
+        }
+
+        let mut format = symphonia::default::get_probe().probe(
+            &hint,
+            stream,
+            FormatOptions::default(),
+            MetadataOptions::default(),
+        )?;
+
+        let mut packets = Vec::new();
+        let mut skipped = 0;
+
+        loop {
+            if packets.len() >= max_packets {
+                break;
+            }
+            match format.next_packet() {
+                Ok(Some(packet)) => {
+                    if packet.track_id == target_track_id {
+                        if skipped < skip_packets {
+                            skipped += 1;
+                            continue;
+                        }
+                        // Convert symphonia Timestamp/Duration to u64 via
+                        // format!+parse — these newtypes have private inner
+                        // fields but implement Display.
+                        let pts = format!("{}", packet.pts).parse::<u64>().unwrap_or(0);
+                        let dts = format!("{}", packet.dts).parse::<u64>().unwrap_or(0);
+                        let dur = format!("{}", packet.dur).parse::<u64>().unwrap_or(0);
+                        packets.push(MediaPacket {
+                            track_id: packet.track_id,
+                            pts,
+                            dts,
+                            duration: dur,
+                            is_keyframe: true,
+                            data: packet.data.to_vec(),
+                        });
+                    }
+                }
+                Ok(None) => break,
+                Err(symphonia::core::errors::Error::IoError(e))
+                    if e.kind() == std::io::ErrorKind::UnexpectedEof =>
+                {
+                    break;
+                }
+                Err(_) => break,
+            }
+        }
+
+        Ok(packets)
+    }
+
+    #[cfg(not(feature = "casting"))]
+    pub fn extract_track_packets(
+        _path: &Path,
+        _target_track_id: u32,
+        _skip_packets: usize,
+        _max_packets: usize,
+    ) -> Result<Vec<MediaPacket>> {
+        Err(anyhow::anyhow!("Casting/Symphonia feature not enabled"))
+    }
+}

--- a/crates/vuio-core/src/media/remux/mkv_demuxer.rs
+++ b/crates/vuio-core/src/media/remux/mkv_demuxer.rs
@@ -11,17 +11,36 @@ pub enum TrackKind {
     Other,
 }
 
+/// The subset of codecs this remuxer can pass through into browser-playable fMP4.
+///
+/// This is a passthrough remuxer, not a transcoder: everything here is real content
+/// Symphonia can identify (E-AC-3/AC-3/DTS/TrueHD audio, VP9/AV1 video, ...), but with
+/// no decoder/encoder in the pipeline those tracks are marked `Unsupported` and left out
+/// of what gets offered to the browser rather than shipped as a broken stream.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub enum TrackCodec {
+    Avc,
+    Hevc,
+    Aac,
+    #[default]
+    Unsupported,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TrackInfo {
     pub id: u32,
     pub track_kind: TrackKind,
     pub codec: String,
+    pub codec_kind: TrackCodec,
     pub language: Option<String>,
     pub name: Option<String>,
     pub sample_rate: Option<u32>,
     pub channels: Option<u8>,
     pub width: Option<u32>,
     pub height: Option<u32>,
+    /// Raw decoder config record for `codec_kind`: an AVC/HEVCDecoderConfigurationRecord
+    /// for video (Matroska's CodecPrivate for these codecs already *is* this record), or
+    /// the raw AudioSpecificConfig for AAC. Empty when `codec_kind` is `Unsupported`.
     pub extra_data: Vec<u8>,
 }
 
@@ -47,6 +66,24 @@ pub struct FileInfo {
     pub duration_secs: Option<f64>,
 }
 
+/// The first video track this remuxer can pass through into browser-playable fMP4.
+pub fn browser_video_track(tracks: &[TrackInfo]) -> Option<&TrackInfo> {
+    tracks.iter().find(|t| {
+        t.track_kind == TrackKind::Video && matches!(t.codec_kind, TrackCodec::Avc | TrackCodec::Hevc)
+    })
+}
+
+/// Audio tracks this remuxer can pass through into browser-playable fMP4, in the same
+/// order used for their `audio/{idx}/...` HLS rendition URLs. Both the playlist side
+/// (`HlsGenerator`) and the segment-serving side (`web::remux_streaming`) must apply
+/// this exact filter/order, or `idx` stops meaning the same track on both ends.
+pub fn browser_audio_tracks(tracks: &[TrackInfo]) -> Vec<&TrackInfo> {
+    tracks
+        .iter()
+        .filter(|t| t.track_kind == TrackKind::Audio && t.codec_kind == TrackCodec::Aac)
+        .collect()
+}
+
 pub struct MkvDemuxer;
 
 impl MkvDemuxer {
@@ -54,10 +91,16 @@ impl MkvDemuxer {
     /// info such as duration.
     #[cfg(feature = "casting")]
     pub fn inspect(path: &Path) -> Result<FileInfo> {
+        use symphonia::core::codecs::audio::well_known::CODEC_ID_AAC;
+        use symphonia::core::codecs::video::well_known::extra_data::{
+            VIDEO_EXTRA_DATA_ID_AVC_DECODER_CONFIG, VIDEO_EXTRA_DATA_ID_HEVC_DECODER_CONFIG,
+        };
+        use symphonia::core::codecs::video::well_known::{CODEC_ID_H264, CODEC_ID_HEVC};
         use symphonia::core::formats::probe::Hint;
         use symphonia::core::formats::FormatOptions;
         use symphonia::core::io::MediaSourceStream;
         use symphonia::core::meta::MetadataOptions;
+        use symphonia::core::units::Timestamp;
 
         let file = std::fs::File::open(path)
             .with_context(|| format!("Failed to open MKV file: {}", path.display()))?;
@@ -77,11 +120,18 @@ impl MkvDemuxer {
             )
             .with_context(|| format!("Failed to probe media file: {}", path.display()))?;
 
-        let mut tracks = Vec::new();
+        // The container's own duration (e.g. Matroska's Segment > Info > Duration),
+        // rather than something derived per-track — this is what drives HLS segment
+        // counts, so a missing/wrong value here truncates playback.
+        let media_info = format.media_info();
+        let duration_secs = match (media_info.time_base, media_info.duration) {
+            (Some(time_base), Some(duration)) => time_base
+                .calc_time(Timestamp::new(duration.get() as i64))
+                .map(|t| t.as_secs_f64()),
+            _ => None,
+        };
 
-        // Try to get file duration from the first track's time base + n_frames,
-        // or from the format's default track.
-        let duration_secs: Option<f64> = None;
+        let mut tracks = Vec::new();
 
         for t in format.tracks() {
             let params = match t.codec_params.as_ref() {
@@ -89,42 +139,67 @@ impl MkvDemuxer {
                 None => continue,
             };
 
-            let kind = if params.video().is_some() {
-                TrackKind::Video
-            } else if params.audio().is_some() {
-                TrackKind::Audio
-            } else {
-                TrackKind::Other
-            };
+            if let Some(v) = params.video() {
+                let (codec_kind, codec_name, extra_data_id) = if v.codec == CODEC_ID_H264 {
+                    (
+                        TrackCodec::Avc,
+                        "H.264",
+                        Some(VIDEO_EXTRA_DATA_ID_AVC_DECODER_CONFIG),
+                    )
+                } else if v.codec == CODEC_ID_HEVC {
+                    (
+                        TrackCodec::Hevc,
+                        "HEVC",
+                        Some(VIDEO_EXTRA_DATA_ID_HEVC_DECODER_CONFIG),
+                    )
+                } else {
+                    (TrackCodec::Unsupported, "Video", None)
+                };
+                let extra_data = extra_data_id
+                    .and_then(|id| v.extra_data.iter().find(|e| e.id == id))
+                    .map(|e| e.data.to_vec())
+                    .unwrap_or_default();
 
-            if kind == TrackKind::Other {
-                continue;
+                tracks.push(TrackInfo {
+                    id: t.id,
+                    track_kind: TrackKind::Video,
+                    codec: codec_name.to_string(),
+                    codec_kind,
+                    language: t.language.clone(),
+                    name: None,
+                    sample_rate: None,
+                    channels: None,
+                    width: v.width.map(u32::from),
+                    height: v.height.map(u32::from),
+                    extra_data,
+                });
+            } else if let Some(a) = params.audio() {
+                let (codec_kind, codec_name) = if a.codec == CODEC_ID_AAC {
+                    (TrackCodec::Aac, "AAC")
+                } else {
+                    (TrackCodec::Unsupported, "Audio")
+                };
+                let extra_data = if codec_kind == TrackCodec::Aac {
+                    a.extra_data.as_ref().map(|d| d.to_vec()).unwrap_or_default()
+                } else {
+                    Vec::new()
+                };
+
+                tracks.push(TrackInfo {
+                    id: t.id,
+                    track_kind: TrackKind::Audio,
+                    codec: codec_name.to_string(),
+                    codec_kind,
+                    language: t.language.clone(),
+                    name: None,
+                    sample_rate: a.sample_rate,
+                    channels: a.channels.clone().map(|c| c.count() as u8),
+                    width: None,
+                    height: None,
+                    extra_data,
+                });
             }
-
-            let codec = format!("{:?}", params);
-            let sample_rate = params.audio().and_then(|a| a.sample_rate);
-            let channels = params
-                .audio()
-                .and_then(|a| a.channels.clone())
-                .map(|c| c.count() as u8);
-            let width = params.video().and_then(|v| v.width).map(u32::from);
-            let height = params.video().and_then(|v| v.height).map(u32::from);
-            let extra_data = Vec::new();
-
-            let language = t.language.clone();
-
-            tracks.push(TrackInfo {
-                id: t.id,
-                track_kind: kind,
-                codec,
-                language,
-                name: None,
-                sample_rate,
-                channels,
-                width,
-                height,
-                extra_data,
-            });
+            // Subtitle and other track kinds aren't part of the browser remux path.
         }
 
         Ok(FileInfo {
@@ -143,19 +218,36 @@ impl MkvDemuxer {
         Self::inspect(path).map(|fi| fi.tracks)
     }
 
-    /// Extract packets for a given track, skipping the first `skip_packets` and
-    /// returning at most `max_packets`.
+    /// Extract packets for `target_track_id` covering roughly `target_duration_secs` of
+    /// content, starting at (or just before) `start_secs` into the stream. Timestamps
+    /// are rescaled from the track's native timebase (Matroska's `TimestampScale`,
+    /// typically 1ms ticks) into `output_timescale` — the fMP4 writer's `mdhd`/`trun`
+    /// boxes declare `output_timescale` as the track's timescale, so packet ticks must
+    /// already be expressed in it, or every sample's duration ends up off by that scale
+    /// factor.
+    ///
+    /// Stopping by accumulated duration rather than a fixed packet count matters: a
+    /// fixed count tuned for one frame rate silently produces overlapping (too long) or
+    /// gapped (too short) segments at any other frame rate, and either can make MSE
+    /// reject appended segments or show visible stutter/duplication at segment
+    /// boundaries.
     #[cfg(feature = "casting")]
     pub fn extract_track_packets(
         path: &Path,
         target_track_id: u32,
-        skip_packets: usize,
-        max_packets: usize,
+        codec: TrackCodec,
+        output_timescale: u32,
+        start_secs: f64,
+        target_duration_secs: f64,
     ) -> Result<Vec<MediaPacket>> {
+        // A safety valve, not a tuning knob: guards against runaway loops if a track's
+        // packets never accumulate to `target_duration_secs` (e.g. a corrupt duration).
+        const MAX_PACKETS_PER_SEGMENT: usize = 4096;
         use symphonia::core::formats::probe::Hint;
-        use symphonia::core::formats::FormatOptions;
+        use symphonia::core::formats::{FormatOptions, SeekMode, SeekTo};
         use symphonia::core::io::MediaSourceStream;
         use symphonia::core::meta::MetadataOptions;
+        use symphonia::core::units::Time;
 
         let file = std::fs::File::open(path)?;
         let stream = MediaSourceStream::new(Box::new(file), Default::default());
@@ -172,35 +264,79 @@ impl MkvDemuxer {
             MetadataOptions::default(),
         )?;
 
+        let track_time_base = format
+            .tracks()
+            .iter()
+            .find(|t| t.id == target_track_id)
+            .and_then(|t| t.time_base);
+
+        // Seek to (at or before) the segment's start time instead of walking every
+        // packet from the beginning of the file on every request — re-scanning from
+        // zero for each of a few hundred segments is O(n^2) over a playback session.
+        // A failed seek (e.g. `start_secs` is 0 and there's nothing to seek past) just
+        // leaves the reader at the start, which is already correct.
+        //
+        // Coarse rather than Accurate: an HLS segment has to begin at a random-access
+        // point or a player starting there has no reference frame to decode against.
+        // Coarse lands on the container's own cue point (a keyframe) at or before the
+        // requested time, where Accurate lands on the nearest sample — which is usually
+        // mid-GOP, and produced segments a player could not start on.
+        let target_time = Time::try_from_secs_f64(start_secs.max(0.0)).unwrap_or(Time::ZERO);
+        let _ = format.seek(
+            SeekMode::Coarse,
+            SeekTo::Time {
+                time: target_time,
+                track_id: Some(target_track_id),
+            },
+        );
+
+        let target_ticks =
+            (target_duration_secs.max(0.0) * output_timescale as f64).round() as u64;
+
         let mut packets = Vec::new();
-        let mut skipped = 0;
+        let mut accumulated_ticks: u64 = 0;
 
         loop {
-            if packets.len() >= max_packets {
+            if packets.len() >= MAX_PACKETS_PER_SEGMENT {
+                break;
+            }
+            // Never stop on an empty segment — always take at least one packet so a
+            // segment request near the end of the stream doesn't come back empty.
+            if accumulated_ticks >= target_ticks && !packets.is_empty() {
                 break;
             }
             match format.next_packet() {
                 Ok(Some(packet)) => {
-                    if packet.track_id == target_track_id {
-                        if skipped < skip_packets {
-                            skipped += 1;
-                            continue;
-                        }
-                        // Convert symphonia Timestamp/Duration to u64 via
-                        // format!+parse — these newtypes have private inner
-                        // fields but implement Display.
-                        let pts = format!("{}", packet.pts).parse::<u64>().unwrap_or(0);
-                        let dts = format!("{}", packet.dts).parse::<u64>().unwrap_or(0);
-                        let dur = format!("{}", packet.dur).parse::<u64>().unwrap_or(0);
-                        packets.push(MediaPacket {
-                            track_id: packet.track_id,
-                            pts,
-                            dts,
-                            duration: dur,
-                            is_keyframe: true,
-                            data: packet.data.to_vec(),
-                        });
+                    if packet.track_id != target_track_id {
+                        continue;
                     }
+                    let rescale = |ticks: i64| -> u64 {
+                        match track_time_base {
+                            Some(tb) => rescale_ticks(ticks, tb, output_timescale),
+                            None => ticks.max(0) as u64,
+                        }
+                    };
+                    let pts = rescale(packet.pts.get());
+                    let dts = rescale(packet.dts.get());
+                    let dur = rescale(packet.dur.get() as i64);
+                    let is_keyframe = packet_is_keyframe(&packet.data, codec);
+                    // Guarantee the segment opens on a random-access point even where
+                    // the container's cue index is sparse enough that the seek above
+                    // landed mid-GOP. Dropping these leading frames loses nothing: they
+                    // depend on references the player would not have when starting here,
+                    // and the previous segment already covers their span.
+                    if packets.is_empty() && !is_keyframe {
+                        continue;
+                    }
+                    accumulated_ticks += dur;
+                    packets.push(MediaPacket {
+                        track_id: packet.track_id,
+                        pts,
+                        dts,
+                        duration: dur,
+                        is_keyframe,
+                        data: packet.data.to_vec(),
+                    });
                 }
                 Ok(None) => break,
                 Err(symphonia::core::errors::Error::IoError(e))
@@ -212,6 +348,8 @@ impl MkvDemuxer {
             }
         }
 
+        derive_decode_timestamps(&mut packets);
+
         Ok(packets)
     }
 
@@ -219,9 +357,91 @@ impl MkvDemuxer {
     pub fn extract_track_packets(
         _path: &Path,
         _target_track_id: u32,
-        _skip_packets: usize,
-        _max_packets: usize,
+        _codec: TrackCodec,
+        _output_timescale: u32,
+        _start_secs: f64,
+        _target_duration_secs: f64,
     ) -> Result<Vec<MediaPacket>> {
         Err(anyhow::anyhow!("Casting/Symphonia feature not enabled"))
     }
+}
+
+/// Fill in each packet's decode timestamp for a run of packets that are in decode order
+/// but carry only presentation timestamps.
+///
+/// Matroska stores a single timestamp per block — the *presentation* time — with blocks
+/// laid out in decode order, and no decode timestamps anywhere. ISO-BMFF needs the
+/// opposite: a monotonically increasing decode timeline (`tfdt` plus per-sample
+/// durations) with a separate composition offset per sample. Symphonia passes the block
+/// timestamp through as both `pts` and `dts`, so without this every sample would claim
+/// `pts == dts` and B-frame content would be handed to the player in decode order —
+/// visibly the wrong frame order, since nothing else in the fragment carries
+/// presentation timing.
+///
+/// Recovering the decode timeline needs no lookahead or bitstream parsing: each frame is
+/// decoded exactly once and presented exactly once, so the multiset of decode timestamps
+/// is precisely the multiset of presentation timestamps. Sorting this run's presentation
+/// timestamps therefore yields the decode timeline directly, and `pts - dts` recovers
+/// each frame's composition offset (negative for frames presented before their decode
+/// position, which `trun` version 1 stores as a signed value).
+#[cfg(feature = "casting")]
+fn derive_decode_timestamps(packets: &mut [MediaPacket]) {
+    let mut decode_times: Vec<u64> = packets.iter().map(|p| p.pts).collect();
+    decode_times.sort_unstable();
+    for (packet, dts) in packets.iter_mut().zip(decode_times) {
+        packet.dts = dts;
+    }
+}
+
+/// Convert a tick count from a track's native timebase into `output_timescale` ticks
+/// per second (e.g. Matroska's default 1ms-per-tick timebase into fMP4's 90kHz video
+/// timescale). Uses 128-bit arithmetic since `ticks * numer * output_timescale` can
+/// exceed 64 bits for a multi-hour file's later timestamps.
+#[cfg(feature = "casting")]
+fn rescale_ticks(ticks: i64, time_base: symphonia::core::units::TimeBase, output_timescale: u32) -> u64 {
+    let ticks = i128::from(ticks.max(0));
+    let numer = i128::from(time_base.numer.get());
+    let denom = i128::from(time_base.denom.get());
+    let output_timescale = i128::from(output_timescale);
+    (ticks * numer * output_timescale / denom).max(0) as u64
+}
+
+/// Whether a length-prefixed AVC/HEVC sample contains a random-access (IDR/IRAP) NAL
+/// unit. Matroska already stores AVC/HEVC samples length-prefixed (matching ISO-BMFF),
+/// so no Annex-B start-code conversion is needed here — just walk the NAL units.
+///
+/// Assumes a 4-byte NAL length prefix, which is what Matroska muxers use in practice
+/// (the AVC/HEVCDecoderConfigurationRecord's `lengthSizeMinusOne` is almost always 3).
+#[cfg(feature = "casting")]
+fn packet_is_keyframe(data: &[u8], codec: TrackCodec) -> bool {
+    match codec {
+        TrackCodec::Avc => nal_units(data, 4).any(|nal| !nal.is_empty() && (nal[0] & 0x1F) == 5),
+        TrackCodec::Hevc => {
+            nal_units(data, 4).any(|nal| nal.len() >= 2 && matches!((nal[0] >> 1) & 0x3F, 16..=23))
+        }
+        // Every AAC frame (and anything else passed through unexamined) is
+        // independently decodable, so `true` is correct here, not a placeholder.
+        _ => true,
+    }
+}
+
+#[cfg(feature = "casting")]
+fn nal_units(data: &[u8], length_size: usize) -> impl Iterator<Item = &[u8]> + '_ {
+    let mut pos = 0usize;
+    std::iter::from_fn(move || {
+        if pos + length_size > data.len() {
+            return None;
+        }
+        let mut len = 0usize;
+        for &b in &data[pos..pos + length_size] {
+            len = (len << 8) | (b as usize);
+        }
+        pos += length_size;
+        if pos + len > data.len() {
+            return None;
+        }
+        let nal = &data[pos..pos + len];
+        pos += len;
+        Some(nal)
+    })
 }

--- a/crates/vuio-core/src/media/remux/mod.rs
+++ b/crates/vuio-core/src/media/remux/mod.rs
@@ -1,0 +1,7 @@
+pub mod fmp4_writer;
+pub mod hls;
+pub mod mkv_demuxer;
+
+pub use fmp4_writer::*;
+pub use hls::*;
+pub use mkv_demuxer::*;

--- a/crates/vuio-core/src/web/mod.rs
+++ b/crates/vuio-core/src/web/mod.rs
@@ -147,12 +147,20 @@ pub fn create_router<D: DatabaseManager + 'static>(state: AppState<D>) -> Router
             get(remux_streaming::serve_hls_audio_playlist::<D>),
         )
         .route(
-            "/media/{id}/hls/init.mp4",
-            get(remux_streaming::serve_hls_init_segment::<D>),
+            "/media/{id}/hls/video/init.mp4",
+            get(remux_streaming::serve_hls_video_init_segment::<D>),
         )
         .route(
-            "/media/{id}/hls/segment/{seq}",
-            get(remux_streaming::serve_hls_media_segment::<D>),
+            "/media/{id}/hls/video/segment/{seq}",
+            get(remux_streaming::serve_hls_video_segment::<D>),
+        )
+        .route(
+            "/media/{id}/hls/audio/{idx}/init.mp4",
+            get(remux_streaming::serve_hls_audio_init_segment::<D>),
+        )
+        .route(
+            "/media/{id}/hls/audio/{idx}/segment/{seq}",
+            get(remux_streaming::serve_hls_audio_segment::<D>),
         );
 
     router

--- a/crates/vuio-core/src/web/mod.rs
+++ b/crates/vuio-core/src/web/mod.rs
@@ -7,6 +7,8 @@ pub mod eventing;
 mod format;
 #[cfg(feature = "mcp")]
 pub mod mcp;
+#[cfg(feature = "casting")]
+pub mod remux_streaming;
 pub mod soap;
 pub mod streaming;
 pub mod subtitles;
@@ -112,7 +114,7 @@ pub fn create_router<D: DatabaseManager + 'static>(state: AppState<D>) -> Router
         asset_routes = asset_routes.route("/assets/{file}", get(ui::asset_handler));
     }
 
-    Router::new()
+    let router = Router::new()
         .route("/login", get(auth::login_page::<D>).post(auth::login::<D>))
         .route("/description.xml", get(soap::description_handler::<D>))
         .route("/ContentDirectory.xml", get(soap::content_directory_scpd))
@@ -128,7 +130,32 @@ pub fn create_router<D: DatabaseManager + 'static>(state: AppState<D>) -> Router
         .route(
             "/media/{id}",
             get(streaming::serve_media::<D>).head(streaming::serve_media::<D>),
+        );
+
+    #[cfg(feature = "casting")]
+    let router = router
+        .route(
+            "/media/{id}/hls/master.m3u8",
+            get(remux_streaming::serve_hls_master::<D>),
         )
+        .route(
+            "/media/{id}/hls/video/index.m3u8",
+            get(remux_streaming::serve_hls_video_playlist::<D>),
+        )
+        .route(
+            "/media/{id}/hls/audio/{idx}/index.m3u8",
+            get(remux_streaming::serve_hls_audio_playlist::<D>),
+        )
+        .route(
+            "/media/{id}/hls/init.mp4",
+            get(remux_streaming::serve_hls_init_segment::<D>),
+        )
+        .route(
+            "/media/{id}/hls/segment/{seq}",
+            get(remux_streaming::serve_hls_media_segment::<D>),
+        );
+
+    router
         .route("/media/{id}/cover", get(streaming::serve_cover::<D>))
         .route("/media/{id}/subtitle", get(streaming::serve_subtitle::<D>))
         .route(
@@ -142,3 +169,4 @@ pub fn create_router<D: DatabaseManager + 'static>(state: AppState<D>) -> Router
         .merge(management_routes)
         .with_state(state)
 }
+

--- a/crates/vuio-core/src/web/remux_streaming.rs
+++ b/crates/vuio-core/src/web/remux_streaming.rs
@@ -1,9 +1,18 @@
 //! HLS remux streaming endpoints for MKV web playback.
+//!
+//! Every rendition (the video track, and each browser-playable — i.e. AAC — audio
+//! track) is served as its own self-contained single-track fMP4 stream: its own
+//! `index.m3u8`, its own `init.mp4` (a single-track `moov`, not one shared between
+//! renditions), and its own numbered segments. MSE requires this: a `SourceBuffer` for
+//! one track cannot be initialised from a `moov` that also describes another track.
 
 use crate::{
     database::DatabaseManager,
     error::AppError,
-    media::remux::{Fmp4Writer, HlsGenerator, MkvDemuxer, TrackKind},
+    media::remux::{
+        mkv_demuxer::{browser_audio_tracks, browser_video_track, FileInfo, TrackInfo},
+        Fmp4Writer, HlsGenerator, MkvDemuxer,
+    },
     state::AppState,
 };
 use axum::{
@@ -11,20 +20,20 @@ use axum::{
     http::header,
     response::{IntoResponse, Response},
 };
+use std::path::PathBuf;
 use tracing::error;
 
 /// Default segment duration target in seconds.
 const SEGMENT_DURATION_SECS: u32 = 4;
 
-/// Maximum packets to extract per segment request.
-const PACKETS_PER_SEGMENT: usize = 120;
-
-pub async fn serve_hls_master<D: DatabaseManager>(
-    State(state): State<AppState<D>>,
-    Path(id): Path<String>,
-) -> Result<Response, AppError> {
-    let file_id =
-        crate::web::streaming::media_id_from_path_segment(&id).ok_or(AppError::NotFound)?;
+/// Resolve `{id}` to a file path and probe its tracks/duration. A probe failure (e.g.
+/// the file went away) is treated as "no browser-playable tracks" rather than a hard
+/// error, so callers fall through to their normal "unsupported" handling.
+async fn load_file_info<D: DatabaseManager>(
+    state: &AppState<D>,
+    id: &str,
+) -> Result<(PathBuf, FileInfo), AppError> {
+    let file_id = crate::web::streaming::media_id_from_path_segment(id).ok_or(AppError::NotFound)?;
     let file_info = state
         .database
         .get_file_location_by_id(file_id)
@@ -35,12 +44,19 @@ pub async fn serve_hls_master<D: DatabaseManager>(
         })?
         .ok_or(AppError::NotFound)?;
 
-    let info = MkvDemuxer::inspect(&file_info.path).unwrap_or_else(|_| {
-        crate::media::remux::mkv_demuxer::FileInfo {
-            tracks: Vec::new(),
-            duration_secs: None,
-        }
+    let info = MkvDemuxer::inspect(&file_info.path).unwrap_or_else(|_| FileInfo {
+        tracks: Vec::new(),
+        duration_secs: None,
     });
+
+    Ok((file_info.path, info))
+}
+
+pub async fn serve_hls_master<D: DatabaseManager>(
+    State(state): State<AppState<D>>,
+    Path(id): Path<String>,
+) -> Result<Response, AppError> {
+    let (_path, info) = load_file_info(&state, &id).await?;
     let master_playlist = HlsGenerator::build_master_playlist(&id, &info.tracks);
 
     Ok((
@@ -57,28 +73,11 @@ pub async fn serve_hls_video_playlist<D: DatabaseManager>(
     State(state): State<AppState<D>>,
     Path(id): Path<String>,
 ) -> Result<Response, AppError> {
-    let file_id =
-        crate::web::streaming::media_id_from_path_segment(&id).ok_or(AppError::NotFound)?;
-    let file_info = state
-        .database
-        .get_file_location_by_id(file_id)
-        .await
-        .map_err(|_| AppError::NotFound)?
-        .ok_or(AppError::NotFound)?;
-
-    let info = MkvDemuxer::inspect(&file_info.path).unwrap_or_else(|_| {
-        crate::media::remux::mkv_demuxer::FileInfo {
-            tracks: Vec::new(),
-            duration_secs: None,
-        }
-    });
-
-    let duration_secs = info.duration_secs.unwrap_or(40.0);
-    let segment_count =
-        (duration_secs / SEGMENT_DURATION_SECS as f64).ceil().max(1.0) as usize;
+    let (_path, info) = load_file_info(&state, &id).await?;
+    browser_video_track(&info.tracks).ok_or(AppError::NotFound)?;
 
     let playlist =
-        HlsGenerator::build_media_playlist("../init.mp4", segment_count, SEGMENT_DURATION_SECS);
+        HlsGenerator::build_media_playlist(info.duration_secs.unwrap_or(0.0), SEGMENT_DURATION_SECS);
 
     Ok((
         [
@@ -92,32 +91,16 @@ pub async fn serve_hls_video_playlist<D: DatabaseManager>(
 
 pub async fn serve_hls_audio_playlist<D: DatabaseManager>(
     State(state): State<AppState<D>>,
-    Path((id, _audio_idx)): Path<(String, usize)>,
+    Path((id, audio_idx)): Path<(String, usize)>,
 ) -> Result<Response, AppError> {
-    let file_id =
-        crate::web::streaming::media_id_from_path_segment(&id).ok_or(AppError::NotFound)?;
-    let file_info = state
-        .database
-        .get_file_location_by_id(file_id)
-        .await
-        .map_err(|_| AppError::NotFound)?
+    let (_path, info) = load_file_info(&state, &id).await?;
+    browser_audio_tracks(&info.tracks)
+        .get(audio_idx)
         .ok_or(AppError::NotFound)?;
 
-    let info = MkvDemuxer::inspect(&file_info.path).unwrap_or_else(|_| {
-        crate::media::remux::mkv_demuxer::FileInfo {
-            tracks: Vec::new(),
-            duration_secs: None,
-        }
-    });
-
-    let duration_secs = info.duration_secs.unwrap_or(40.0);
-    let segment_count =
-        (duration_secs / SEGMENT_DURATION_SECS as f64).ceil().max(1.0) as usize;
-
-    // Audio init segments are served from the audio/{idx}/ path, so the
-    // relative URI goes up one level to reach the shared namespace.
+    // Every rendition of the same file shares the same overall timeline.
     let playlist =
-        HlsGenerator::build_media_playlist("../../init.mp4", segment_count, SEGMENT_DURATION_SECS);
+        HlsGenerator::build_media_playlist(info.duration_secs.unwrap_or(0.0), SEGMENT_DURATION_SECS);
 
     Ok((
         [
@@ -129,120 +112,88 @@ pub async fn serve_hls_audio_playlist<D: DatabaseManager>(
         .into_response())
 }
 
-pub async fn serve_hls_init_segment<D: DatabaseManager>(
-    State(state): State<AppState<D>>,
-    Path(id): Path<String>,
-) -> Result<Response, AppError> {
-    let file_id =
-        crate::web::streaming::media_id_from_path_segment(&id).ok_or(AppError::NotFound)?;
-    let file_info = state
-        .database
-        .get_file_location_by_id(file_id)
-        .await
-        .map_err(|_| AppError::NotFound)?
-        .ok_or(AppError::NotFound)?;
-
-    let info = MkvDemuxer::inspect(&file_info.path).unwrap_or_else(|_| {
-        crate::media::remux::mkv_demuxer::FileInfo {
-            tracks: Vec::new(),
-            duration_secs: None,
-        }
-    });
-
-    // Build ftyp + moov for *each* relevant track so that both video and audio
-    // decoders can initialise from this single init segment.
+fn init_segment_response(track: &TrackInfo) -> Response {
     let mut init_bytes = Fmp4Writer::build_ftyp();
+    init_bytes.extend_from_slice(&Fmp4Writer::build_moov(track));
 
-    let video_track = info
-        .tracks
-        .iter()
-        .find(|t| t.track_kind == TrackKind::Video);
-    let first_audio = info
-        .tracks
-        .iter()
-        .find(|t| t.track_kind == TrackKind::Audio);
-
-    if let Some(track) = video_track {
-        let moov = Fmp4Writer::build_moov(track);
-        init_bytes.extend_from_slice(&moov);
-    }
-    if let Some(track) = first_audio {
-        let moov = Fmp4Writer::build_moov(track);
-        init_bytes.extend_from_slice(&moov);
-    }
-
-    // If there were no tracks at all, still return a valid (though empty) ftyp.
-    Ok((
+    (
         [
             (header::CONTENT_TYPE, "video/mp4"),
             (header::CACHE_CONTROL, "public, max-age=3600"),
         ],
         init_bytes,
     )
-        .into_response())
+        .into_response()
 }
 
-pub async fn serve_hls_media_segment<D: DatabaseManager>(
+pub async fn serve_hls_video_init_segment<D: DatabaseManager>(
     State(state): State<AppState<D>>,
-    Path((id, seq)): Path<(String, u32)>,
+    Path(id): Path<String>,
 ) -> Result<Response, AppError> {
-    let file_id =
-        crate::web::streaming::media_id_from_path_segment(&id).ok_or(AppError::NotFound)?;
-    let file_info = state
-        .database
-        .get_file_location_by_id(file_id)
-        .await
-        .map_err(|_| AppError::NotFound)?
-        .ok_or(AppError::NotFound)?;
+    let (_path, info) = load_file_info(&state, &id).await?;
+    let video_track = browser_video_track(&info.tracks).ok_or(AppError::NotFound)?;
+    Ok(init_segment_response(video_track))
+}
 
-    let info = MkvDemuxer::inspect(&file_info.path).unwrap_or_else(|_| {
-        crate::media::remux::mkv_demuxer::FileInfo {
-            tracks: Vec::new(),
-            duration_secs: None,
-        }
-    });
+pub async fn serve_hls_audio_init_segment<D: DatabaseManager>(
+    State(state): State<AppState<D>>,
+    Path((id, audio_idx)): Path<(String, usize)>,
+) -> Result<Response, AppError> {
+    let (_path, info) = load_file_info(&state, &id).await?;
+    let audio_tracks = browser_audio_tracks(&info.tracks);
+    let track = audio_tracks.get(audio_idx).copied().ok_or(AppError::NotFound)?;
+    Ok(init_segment_response(track))
+}
 
-    let video_track = info
-        .tracks
-        .iter()
-        .find(|t| t.track_kind == TrackKind::Video)
-        .cloned()
-        .unwrap_or_else(|| crate::media::remux::mkv_demuxer::TrackInfo {
-            id: 1,
-            track_kind: TrackKind::Video,
-            codec: String::new(),
-            language: None,
-            name: None,
-            sample_rate: None,
-            channels: None,
-            width: None,
-            height: None,
-            extra_data: Vec::new(),
-        });
+/// Extract packets for `track` starting at `seq * SEGMENT_DURATION_SECS` and mux them
+/// into an fMP4 segment (`moof` + `mdat`). Shared by the video- and audio-segment
+/// routes — they differ only in which track they resolve `{id}`/`{idx}` to.
+fn build_segment_response(path: &std::path::Path, track: &TrackInfo, seq: u32) -> Response {
+    let timescale = Fmp4Writer::timescale_for(track);
+    let start_secs = seq as f64 * SEGMENT_DURATION_SECS as f64;
 
-    let timescale = Fmp4Writer::timescale_for(&video_track);
-
-    // Skip packets for previous segments. This is a simple but functional
-    // approach — each segment request re-opens the file and skips ahead.
-    let skip = seq as usize * PACKETS_PER_SEGMENT;
     let packets = MkvDemuxer::extract_track_packets(
-        &file_info.path,
-        video_track.id,
-        skip,
-        PACKETS_PER_SEGMENT,
+        path,
+        track.id,
+        track.codec_kind,
+        timescale,
+        start_secs,
+        SEGMENT_DURATION_SECS as f64,
     )
     .unwrap_or_default();
 
-    let base_decode_time = seq as u64 * SEGMENT_DURATION_SECS as u64 * timescale as u64;
-    let segment_bytes =
-        Fmp4Writer::build_segment(seq + 1, &video_track, base_decode_time, &packets);
+    // Seeking lands at (or before) `start_secs`, not exactly on it, so the fragment's
+    // base decode time comes from the packets themselves (`build_segment` takes it from
+    // the first one's decode timestamp). The nominal `seq`-derived position is only a
+    // fallback for a segment that came back empty.
+    let nominal_decode_time = (start_secs * timescale as f64).round() as u64;
+    let segment_bytes = Fmp4Writer::build_segment(seq + 1, track, nominal_decode_time, &packets);
 
-    Ok((
+    (
         [
             (header::CONTENT_TYPE, "video/mp4"),
             (header::CACHE_CONTROL, "public, max-age=3600"),
         ],
         segment_bytes,
     )
-        .into_response())
+        .into_response()
+}
+
+pub async fn serve_hls_video_segment<D: DatabaseManager>(
+    State(state): State<AppState<D>>,
+    Path((id, seq)): Path<(String, u32)>,
+) -> Result<Response, AppError> {
+    let (path, info) = load_file_info(&state, &id).await?;
+    let video_track = browser_video_track(&info.tracks).ok_or(AppError::NotFound)?;
+    Ok(build_segment_response(&path, video_track, seq))
+}
+
+pub async fn serve_hls_audio_segment<D: DatabaseManager>(
+    State(state): State<AppState<D>>,
+    Path((id, audio_idx, seq)): Path<(String, usize, u32)>,
+) -> Result<Response, AppError> {
+    let (path, info) = load_file_info(&state, &id).await?;
+    let audio_tracks = browser_audio_tracks(&info.tracks);
+    let track = audio_tracks.get(audio_idx).copied().ok_or(AppError::NotFound)?;
+    Ok(build_segment_response(&path, track, seq))
 }

--- a/crates/vuio-core/src/web/remux_streaming.rs
+++ b/crates/vuio-core/src/web/remux_streaming.rs
@@ -1,0 +1,248 @@
+//! HLS remux streaming endpoints for MKV web playback.
+
+use crate::{
+    database::DatabaseManager,
+    error::AppError,
+    media::remux::{Fmp4Writer, HlsGenerator, MkvDemuxer, TrackKind},
+    state::AppState,
+};
+use axum::{
+    extract::{Path, State},
+    http::header,
+    response::{IntoResponse, Response},
+};
+use tracing::error;
+
+/// Default segment duration target in seconds.
+const SEGMENT_DURATION_SECS: u32 = 4;
+
+/// Maximum packets to extract per segment request.
+const PACKETS_PER_SEGMENT: usize = 120;
+
+pub async fn serve_hls_master<D: DatabaseManager>(
+    State(state): State<AppState<D>>,
+    Path(id): Path<String>,
+) -> Result<Response, AppError> {
+    let file_id =
+        crate::web::streaming::media_id_from_path_segment(&id).ok_or(AppError::NotFound)?;
+    let file_info = state
+        .database
+        .get_file_location_by_id(file_id)
+        .await
+        .map_err(|e| {
+            error!("Database error getting file by ID {}: {}", file_id, e);
+            AppError::NotFound
+        })?
+        .ok_or(AppError::NotFound)?;
+
+    let info = MkvDemuxer::inspect(&file_info.path).unwrap_or_else(|_| {
+        crate::media::remux::mkv_demuxer::FileInfo {
+            tracks: Vec::new(),
+            duration_secs: None,
+        }
+    });
+    let master_playlist = HlsGenerator::build_master_playlist(&id, &info.tracks);
+
+    Ok((
+        [
+            (header::CONTENT_TYPE, "application/x-mpegURL"),
+            (header::CACHE_CONTROL, "no-cache"),
+        ],
+        master_playlist,
+    )
+        .into_response())
+}
+
+pub async fn serve_hls_video_playlist<D: DatabaseManager>(
+    State(state): State<AppState<D>>,
+    Path(id): Path<String>,
+) -> Result<Response, AppError> {
+    let file_id =
+        crate::web::streaming::media_id_from_path_segment(&id).ok_or(AppError::NotFound)?;
+    let file_info = state
+        .database
+        .get_file_location_by_id(file_id)
+        .await
+        .map_err(|_| AppError::NotFound)?
+        .ok_or(AppError::NotFound)?;
+
+    let info = MkvDemuxer::inspect(&file_info.path).unwrap_or_else(|_| {
+        crate::media::remux::mkv_demuxer::FileInfo {
+            tracks: Vec::new(),
+            duration_secs: None,
+        }
+    });
+
+    let duration_secs = info.duration_secs.unwrap_or(40.0);
+    let segment_count =
+        (duration_secs / SEGMENT_DURATION_SECS as f64).ceil().max(1.0) as usize;
+
+    let playlist =
+        HlsGenerator::build_media_playlist("../init.mp4", segment_count, SEGMENT_DURATION_SECS);
+
+    Ok((
+        [
+            (header::CONTENT_TYPE, "application/x-mpegURL"),
+            (header::CACHE_CONTROL, "no-cache"),
+        ],
+        playlist,
+    )
+        .into_response())
+}
+
+pub async fn serve_hls_audio_playlist<D: DatabaseManager>(
+    State(state): State<AppState<D>>,
+    Path((id, _audio_idx)): Path<(String, usize)>,
+) -> Result<Response, AppError> {
+    let file_id =
+        crate::web::streaming::media_id_from_path_segment(&id).ok_or(AppError::NotFound)?;
+    let file_info = state
+        .database
+        .get_file_location_by_id(file_id)
+        .await
+        .map_err(|_| AppError::NotFound)?
+        .ok_or(AppError::NotFound)?;
+
+    let info = MkvDemuxer::inspect(&file_info.path).unwrap_or_else(|_| {
+        crate::media::remux::mkv_demuxer::FileInfo {
+            tracks: Vec::new(),
+            duration_secs: None,
+        }
+    });
+
+    let duration_secs = info.duration_secs.unwrap_or(40.0);
+    let segment_count =
+        (duration_secs / SEGMENT_DURATION_SECS as f64).ceil().max(1.0) as usize;
+
+    // Audio init segments are served from the audio/{idx}/ path, so the
+    // relative URI goes up one level to reach the shared namespace.
+    let playlist =
+        HlsGenerator::build_media_playlist("../../init.mp4", segment_count, SEGMENT_DURATION_SECS);
+
+    Ok((
+        [
+            (header::CONTENT_TYPE, "application/x-mpegURL"),
+            (header::CACHE_CONTROL, "no-cache"),
+        ],
+        playlist,
+    )
+        .into_response())
+}
+
+pub async fn serve_hls_init_segment<D: DatabaseManager>(
+    State(state): State<AppState<D>>,
+    Path(id): Path<String>,
+) -> Result<Response, AppError> {
+    let file_id =
+        crate::web::streaming::media_id_from_path_segment(&id).ok_or(AppError::NotFound)?;
+    let file_info = state
+        .database
+        .get_file_location_by_id(file_id)
+        .await
+        .map_err(|_| AppError::NotFound)?
+        .ok_or(AppError::NotFound)?;
+
+    let info = MkvDemuxer::inspect(&file_info.path).unwrap_or_else(|_| {
+        crate::media::remux::mkv_demuxer::FileInfo {
+            tracks: Vec::new(),
+            duration_secs: None,
+        }
+    });
+
+    // Build ftyp + moov for *each* relevant track so that both video and audio
+    // decoders can initialise from this single init segment.
+    let mut init_bytes = Fmp4Writer::build_ftyp();
+
+    let video_track = info
+        .tracks
+        .iter()
+        .find(|t| t.track_kind == TrackKind::Video);
+    let first_audio = info
+        .tracks
+        .iter()
+        .find(|t| t.track_kind == TrackKind::Audio);
+
+    if let Some(track) = video_track {
+        let moov = Fmp4Writer::build_moov(track);
+        init_bytes.extend_from_slice(&moov);
+    }
+    if let Some(track) = first_audio {
+        let moov = Fmp4Writer::build_moov(track);
+        init_bytes.extend_from_slice(&moov);
+    }
+
+    // If there were no tracks at all, still return a valid (though empty) ftyp.
+    Ok((
+        [
+            (header::CONTENT_TYPE, "video/mp4"),
+            (header::CACHE_CONTROL, "public, max-age=3600"),
+        ],
+        init_bytes,
+    )
+        .into_response())
+}
+
+pub async fn serve_hls_media_segment<D: DatabaseManager>(
+    State(state): State<AppState<D>>,
+    Path((id, seq)): Path<(String, u32)>,
+) -> Result<Response, AppError> {
+    let file_id =
+        crate::web::streaming::media_id_from_path_segment(&id).ok_or(AppError::NotFound)?;
+    let file_info = state
+        .database
+        .get_file_location_by_id(file_id)
+        .await
+        .map_err(|_| AppError::NotFound)?
+        .ok_or(AppError::NotFound)?;
+
+    let info = MkvDemuxer::inspect(&file_info.path).unwrap_or_else(|_| {
+        crate::media::remux::mkv_demuxer::FileInfo {
+            tracks: Vec::new(),
+            duration_secs: None,
+        }
+    });
+
+    let video_track = info
+        .tracks
+        .iter()
+        .find(|t| t.track_kind == TrackKind::Video)
+        .cloned()
+        .unwrap_or_else(|| crate::media::remux::mkv_demuxer::TrackInfo {
+            id: 1,
+            track_kind: TrackKind::Video,
+            codec: String::new(),
+            language: None,
+            name: None,
+            sample_rate: None,
+            channels: None,
+            width: None,
+            height: None,
+            extra_data: Vec::new(),
+        });
+
+    let timescale = Fmp4Writer::timescale_for(&video_track);
+
+    // Skip packets for previous segments. This is a simple but functional
+    // approach — each segment request re-opens the file and skips ahead.
+    let skip = seq as usize * PACKETS_PER_SEGMENT;
+    let packets = MkvDemuxer::extract_track_packets(
+        &file_info.path,
+        video_track.id,
+        skip,
+        PACKETS_PER_SEGMENT,
+    )
+    .unwrap_or_default();
+
+    let base_decode_time = seq as u64 * SEGMENT_DURATION_SECS as u64 * timescale as u64;
+    let segment_bytes =
+        Fmp4Writer::build_segment(seq + 1, &video_track, base_decode_time, &packets);
+
+    Ok((
+        [
+            (header::CONTENT_TYPE, "video/mp4"),
+            (header::CACHE_CONTROL, "public, max-age=3600"),
+        ],
+        segment_bytes,
+    )
+        .into_response())
+}

--- a/crates/vuio-core/src/web/streaming.rs
+++ b/crates/vuio-core/src/web/streaming.rs
@@ -288,7 +288,7 @@ pub async fn serve_media<D: DatabaseManager>(
     Ok(response_builder.status(response_status).body(body)?)
 }
 
-fn media_id_from_path_segment(segment: &str) -> Option<i64> {
+pub(crate) fn media_id_from_path_segment(segment: &str) -> Option<i64> {
     let id = match segment.split_once('.') {
         Some((id, extension)) => {
             if extension.is_empty()

--- a/crates/vuio-core/src/web/ui/dashboard.html
+++ b/crates/vuio-core/src/web/ui/dashboard.html
@@ -672,6 +672,28 @@
             border: 1px solid rgba(255, 255, 255, 0.05);
         }
 
+        .video-audio-track-select {
+            flex-shrink: 0;
+            font-size: 0.8rem;
+            color: var(--text-primary);
+            background: var(--card-bg);
+            border: 1px solid var(--card-border);
+            border-radius: 6px;
+            padding: 0.2rem 0.4rem;
+            max-width: 40%;
+        }
+
+        .video-audio-note {
+            width: 100%;
+            font-size: 0.8rem;
+            color: var(--text-secondary);
+            background: var(--card-bg);
+            border: 1px solid var(--card-border);
+            border-radius: 8px;
+            padding: 0.5rem 0.75rem;
+            margin-top: 0.5rem;
+        }
+
         .video-unsupported {
             width: min(520px, 90vw);
             display: flex;
@@ -1261,9 +1283,13 @@
                     </button>
                 </div>
             </div>
+            <div id="video-audio-unavailable-note" class="video-audio-note" style="display: none;">
+                Audio in this file isn't in a browser-playable format — download it or cast to a device to hear sound.
+            </div>
             <div class="lightbox-meta" style="justify-content: space-between; padding: 0.5rem 0.25rem; display: flex; align-items: center; width: 100%;">
                 <div style="display: flex; align-items: center; gap: 1rem; min-width: 0; flex: 1;">
                     <span id="video-player-title" style="font-weight: 600; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">Video Name</span>
+                    <select id="video-audio-track-select" class="video-audio-track-select" style="display: none;" title="Audio track"></select>
                 </div>
                 <a id="video-player-download" href="" download="" class="lightbox-download-btn" title="Download Video">
                     <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="7 10 12 15 17 10"></polyline><line x1="12" y1="15" x2="12" y2="3"></line></svg>
@@ -2203,6 +2229,7 @@
         async function mountVideoPlayer(file, url) {
             const stage = document.getElementById('video-stage');
             document.getElementById('video-unsupported').style.display = 'none';
+            resetAudioTrackUi();
             stage.style.display = 'block';
             stage.style.removeProperty('--video-ar');
 
@@ -2266,11 +2293,13 @@
         }
 
         async function attachHlsSource(video, url, file) {
-            // Safari plays HLS natively and does not support hls.js's MSE path.
-            if (video.canPlayType('application/vnd.apple.mpegurl')) {
-                video.src = url;
-                return true;
-            }
+            // Prefer hls.js/MSE whenever it's actually usable, rather than trusting
+            // canPlayType('application/vnd.apple.mpegurl') to mean "this is Safari,
+            // use native HLS": recent Chrome also answers non-empty there (some
+            // versions report "maybe") but its native engine doesn't reliably play
+            // this server's fMP4-based HLS — the <video> just hangs at readyState 0
+            // with no error event. Native <video src> is now the true last resort,
+            // for browsers where hls.js reports no MSE support at all (older Safari).
             try {
                 const Hls = await loadHls();
                 if (!Hls || !Hls.isSupported()) throw new Error('Media Source Extensions unavailable');
@@ -2278,14 +2307,64 @@
                 videoHls.on(Hls.Events.ERROR, (event, data) => {
                     if (data && data.fatal) showVideoUnsupported(file);
                 });
+                setupAudioTrackUi(videoHls, Hls);
                 videoHls.loadSource(url);
                 videoHls.attachMedia(video);
                 return true;
             } catch (error) {
+                if (video.canPlayType('application/vnd.apple.mpegurl')) {
+                    video.src = url;
+                    return true;
+                }
                 console.error('HLS playback unavailable:', error);
                 showVideoUnsupported(file);
                 return false;
             }
+        }
+
+        // Populates the audio-track <select> once hls.js knows the master playlist's
+        // #EXT-X-MEDIA:TYPE=AUDIO renditions (only tracks the server found browser
+        // decodable — e.g. AAC — ever appear here), and shows a note instead when the
+        // file has no such track at all (this is expected, not an error, for sources
+        // whose audio is e.g. Dolby Digital/E-AC-3 — no browser can decode that).
+        function setupAudioTrackUi(hls, Hls) {
+            const select = document.getElementById('video-audio-track-select');
+            const note = document.getElementById('video-audio-unavailable-note');
+
+            hls.on(Hls.Events.MANIFEST_PARSED, (event, data) => {
+                if (videoHls !== hls) return;
+                note.style.display = (data.audioTracks || []).length === 0 ? 'block' : 'none';
+            });
+
+            hls.on(Hls.Events.AUDIO_TRACKS_UPDATED, (event, data) => {
+                if (videoHls !== hls) return;
+                const tracks = data.audioTracks || [];
+                if (tracks.length < 2) {
+                    select.style.display = 'none';
+                    select.replaceChildren();
+                    return;
+                }
+                select.replaceChildren(...tracks.map((track, idx) => {
+                    const option = document.createElement('option');
+                    option.value = String(idx);
+                    option.textContent = track.name || track.lang || ('Audio Track ' + (idx + 1));
+                    option.selected = idx === hls.audioTrack;
+                    return option;
+                }));
+                select.style.display = 'inline-block';
+            });
+
+            select.onchange = () => {
+                if (videoHls === hls) hls.audioTrack = Number(select.value);
+            };
+        }
+
+        function resetAudioTrackUi() {
+            const select = document.getElementById('video-audio-track-select');
+            select.style.display = 'none';
+            select.replaceChildren();
+            select.onchange = null;
+            document.getElementById('video-audio-unavailable-note').style.display = 'none';
         }
 
         function showVideoUnsupported(file) {
@@ -2316,6 +2395,7 @@
         // Tears down playback without touching modal visibility, so it can be reused by
         // both the close path and the fall-back-to-unsupported path.
         function teardownVideoPlayback() {
+            resetAudioTrackUi();
             if (videoHls) {
                 videoHls.destroy();
                 videoHls = null;

--- a/crates/vuio-core/src/web/ui/dashboard.html
+++ b/crates/vuio-core/src/web/ui/dashboard.html
@@ -2152,7 +2152,7 @@
         // as unplayable as one holding HEVC. Listed explicitly so the fallback panel
         // appears without first spending a request. Every other extension is attempted
         // and falls back through the <video> error event.
-        const BROWSER_UNPLAYABLE_VIDEO = new Set(['mkv', 'avi', 'wmv', 'flv', 'mpg', 'mpeg']);
+        const BROWSER_UNPLAYABLE_VIDEO = new Set(['avi', 'wmv', 'flv', 'mpg', 'mpeg']);
 
         const PLYR_VERSION = '3.8.4';
         const HLS_VERSION = '1.6.17';
@@ -2190,11 +2190,14 @@
             document.getElementById('video-modal').style.display = 'flex';
             document.addEventListener('keydown', handleVideoKeydown);
 
-            if (BROWSER_UNPLAYABLE_VIDEO.has((file.ext || '').toLowerCase())) {
+            const ext = (file.ext || '').toLowerCase();
+            if (BROWSER_UNPLAYABLE_VIDEO.has(ext)) {
                 showVideoUnsupported(file);
                 return;
             }
-            mountVideoPlayer(file, url);
+
+            const playUrl = ext === 'mkv' ? url + '/hls/master.m3u8' : url;
+            mountVideoPlayer(file, playUrl);
         }
 
         async function mountVideoPlayer(file, url) {


### PR DESCRIPTION
## Summary
Adds `.mkv` container web playback support with RFC 8216 multi-audio track selection without FFmpeg dependencies (keeping dual MIT/Apache-2.0 licensing).

## Key Changes
- **Symphonia Integration**: Enabled `mkv` feature in `vuio-core`.
- **Pure Rust Remuxer Subsystem**:
  - `mkv_demuxer.rs`: Inspects tracks and extracts media packets via Symphonia.
  - `fmp4_writer.rs`: ISO BMFF / fMP4 box serializer (`ftyp`, `moov`, `moof`, `mdat`, `trun`).
  - `hls.rs`: RFC 8216 HLS playlist generator supporting `#EXT-X-MEDIA:TYPE=AUDIO` multi-audio stream selection.
- **Axum Streaming Endpoints**: Exposes `/media/{id}/hls/*` endpoints for playlists, init segments, and media chunks (feature-gated under `casting`).
- **Dashboard Web Player**: Updated UI player logic to mount `.mkv` files via HLS master playlist URL using Plyr + hls.js.

## Verification
- `cargo check --all-targets --all-features`
- `cargo check --all-targets`
- `cargo fmt --all -- --check`
- `cargo test` (221 tests passed)
- `cargo clippy --all-targets --all-features -- -D warnings`